### PR TITLE
Support all uc types with some (hacky) string parsing

### DIFF
--- a/src/include/uc_utils.hpp
+++ b/src/include/uc_utils.hpp
@@ -26,7 +26,7 @@ struct UCType {
 class UCUtils {
 public:
 	static LogicalType ToUCType(const LogicalType &input);
-	static LogicalType TypeToLogicalType(ClientContext &context, const UCAPIColumnDefinition &columnDefinition);
+	static LogicalType TypeToLogicalType(ClientContext &context, const string &columnDefinition);
 	static string TypeToString(const LogicalType &input);
 };
 

--- a/src/storage/uc_table_set.cpp
+++ b/src/storage/uc_table_set.cpp
@@ -21,7 +21,7 @@ UCTableSet::UCTableSet(UCSchemaEntry &schema) : UCInSchemaSet(schema) {
 }
 
 static ColumnDefinition CreateColumnDefinition(ClientContext &context, UCAPIColumnDefinition &coldef) {
-    return {coldef.name, UCUtils::TypeToLogicalType(context, coldef)};
+    return {coldef.name, UCUtils::TypeToLogicalType(context, coldef.type_text)};
 }
 
 void UCTableSet::LoadEntries(ClientContext &context) {

--- a/src/uc_utils.cpp
+++ b/src/uc_utils.cpp
@@ -1,6 +1,9 @@
 #include "uc_utils.hpp"
+#include "duckdb/common/operator/cast_operators.hpp"
 #include "storage/uc_schema_entry.hpp"
 #include "storage/uc_transaction.hpp"
+
+#include <iostream>
 
 namespace duckdb {
 
@@ -25,24 +28,122 @@ string UCUtils::TypeToString(const LogicalType &input) {
 	}
 }
 
-LogicalType UCUtils::TypeToLogicalType(ClientContext &context, const UCAPIColumnDefinition &column_definition) {
-	if (column_definition.type_text == "tinyint") {
-			return LogicalType::TINYINT;
-	} else if (column_definition.type_text == "smallint") {
-        return LogicalType::SMALLINT;
-	} else if (column_definition.type_text == "bigint") {
-        return LogicalType::BIGINT;
-	} else if (column_definition.type_text == "int") {
-        return LogicalType::INTEGER;
-	} else if (column_definition.type_text == "long") {
-        return LogicalType::BIGINT;
-	} else if (column_definition.type_text == "string") {
-        return LogicalType::VARCHAR;
-	}  else if (column_definition.type_text == "timestamp") {
-        return LogicalType::TIMESTAMP;
-    }
+LogicalType UCUtils::TypeToLogicalType(ClientContext &context, const string &type_text) {
+	if (type_text == "tinyint") {
+            return LogicalType::TINYINT;
+	} else if (type_text == "smallint") {
+            return LogicalType::SMALLINT;
+        } else if (type_text == "bigint") {
+            return LogicalType::BIGINT;
+        } else if (type_text == "int") {
+            return LogicalType::INTEGER;
+	} else if (type_text == "long") {
+            return LogicalType::BIGINT;
+	} else if (type_text == "string") {
+            return LogicalType::VARCHAR;
+	} else if (type_text == "double") {
+            return LogicalType::DOUBLE;
+	} else if (type_text == "float") {
+            return LogicalType::FLOAT;
+	} else if (type_text == "boolean") {
+            return LogicalType::BOOLEAN;
+	} else if (type_text == "timestamp") {
+            return LogicalType::TIMESTAMP;
+        } else if (type_text == "binary") {
+            return LogicalType::BLOB;
+        } else if (type_text == "date") {
+            return LogicalType::DATE;
+        } else if (type_text == "timestamp") {
+            return LogicalType::TIMESTAMP; // TODO: Is this the right timestamp
+        } else if (type_text.find("decimal(") == 0) {
+            size_t spec_end = type_text.find(')');
+            if (spec_end != string::npos) {
+                size_t sep = type_text.find(',');
+                auto prec_str = type_text.substr(8, sep - 8);
+                auto scale_str = type_text.substr(sep + 1, spec_end - sep - 1);
+                uint8_t prec = Cast::Operation<string_t, uint8_t>(prec_str);
+                uint8_t scale = Cast::Operation<string_t, uint8_t>(scale_str);
+                return LogicalType::DECIMAL(prec, scale);
+            }
+        } else if (type_text.find("array<") == 0) {
+            size_t type_end = type_text.rfind('>'); // find last, to deal with nested
+            if (type_end != string::npos) {
+                auto child_type_str = type_text.substr(6, type_end - 6);
+                auto child_type = UCUtils::TypeToLogicalType(context, child_type_str);
+                return LogicalType::LIST(child_type);
+            }
+        } else if (type_text.find("map<") == 0) {
+            size_t type_end = type_text.rfind('>'); // find last, to deal with nested
+            if (type_end != string::npos) {
+                // TODO: Factor this and struct parsing into an iterator over ',' separated values
+                vector<LogicalType> key_val;
+                size_t cur = 4;
+                auto nested_opens = 0;
+                for (;;) {
+                    size_t next_sep = cur;
+                    // find the location of the next ',' ignoring nested commas
+                    while (type_text[next_sep] != ',' || nested_opens > 0) {
+                        if (type_text[next_sep] == '<') {
+                            nested_opens++;
+                        } else if (type_text[next_sep] == '>') {
+                            nested_opens--;
+                        }
+                        next_sep++;
+                        if (next_sep == type_end) {
+                            break;
+                        }
+                    }
+                    auto child_str = type_text.substr(cur, next_sep - cur);
+                    auto child_type = UCUtils::TypeToLogicalType(context, child_str);
+                    key_val.push_back(child_type);
+                    if (next_sep == type_end) {
+                        break;
+                    }
+                    cur = next_sep+1;
+                }
+                if (key_val.size() != 2) {
+                    throw NotImplementedException("Invalid map specification with %i types", key_val.size());
+                }
+                return LogicalType::MAP(key_val[0], key_val[1]);
+            }
+        } else if (type_text.find("struct<") == 0) {
+            size_t type_end = type_text.rfind('>'); // find last, to deal with nested
+            if (type_end != string::npos) {
+                child_list_t<LogicalType> children;
+                size_t cur = 7;
+                auto nested_opens = 0;
+                for (;;) {
+                    size_t next_sep = cur;
+                    // find the location of the next ',' ignoring nested commas
+                    while (type_text[next_sep] != ',' || nested_opens > 0) {
+                        if (type_text[next_sep] == '<') {
+                            nested_opens++;
+                        } else if (type_text[next_sep] == '>') {
+                            nested_opens--;
+                        }
+                        next_sep++;
+                        if (next_sep == type_end) {
+                            break;
+                        }
+                    }
+                    auto child_str = type_text.substr(cur, next_sep - cur);
+                    size_t type_sep = child_str.find(':');
+                    if (type_sep == string::npos) {
+                        throw NotImplementedException("Invalid struct child type specifier: %s", child_str);
+                    }
+                    auto child_name = child_str.substr(0, type_sep);
+                    auto child_type = UCUtils::TypeToLogicalType(context, child_str.substr(type_sep+1, string::npos));
+                    children.push_back({child_name, child_type});
+                    if (next_sep == type_end) {
+                        break;
+                    }
+                    cur = next_sep+1;
+                }
+                return LogicalType::STRUCT(children);
+            }
+        }
 
-    throw NotImplementedException("Tried to fallback to unknown type for '%s'", column_definition.type_text);
+    throw NotImplementedException("Tried to fallback to unknown type for '%s'", type_text);
 	// fallback for unknown types
 	return LogicalType::VARCHAR;
 }


### PR DESCRIPTION
This supports all uc types. The string parsing is a little hacky, but does work.

At some point it might be good to switch to parsing the actual json, but for now it is either:
a) incorrect (there's a bug where the json for `decimal` always has prec/scale as `0`) or
b) more complex (the types for map/struct have different names like "integer" vs. "int" in the json spec)

Does seem to work:
![image](https://github.com/duckdb/uc_catalog/assets/178912/57b4ba5f-83ac-43bc-bb30-09aa7f45112a)
