### PR TITLE
add checkpoint support to unity (via delta via FFI)

### DIFF
--- a/.github/workflows/LocalTesting.yml
+++ b/.github/workflows/LocalTesting.yml
@@ -19,7 +19,6 @@ jobs:
       GEN: ninja
       VCPKG_TOOLCHAIN_PATH: ${{ github.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake
       USE_MERGED_VCPKG_MANIFEST: 1
-      UC_TEST_SERVER_RUNNING: 1
       BUILD_EXTENSION_TEST_DEPS: full
 
     steps:
@@ -64,6 +63,9 @@ jobs:
         make release
 
     - name: Test extension
+      env:
+        UC_TEST_SERVER_RUNNING: 1
+        UC_TEST_DATA: unitycatalog/etc/data
       run: |
         # confirm UC test server up
         cat unitycatalog/uc.log

--- a/.github/workflows/LocalTesting.yml
+++ b/.github/workflows/LocalTesting.yml
@@ -70,6 +70,8 @@ jobs:
         # confirm UC test server up
         cat unitycatalog/uc.log
         unitycatalog/bin/uc catalog list
+        # /tmp/marksheet_uniform is currently encoded into the data
+        env -C /tmp ln -s $PWD/unitycatalog/etc/data/external/unity/default/tables/marksheet_uniform
         make test_release
 
     - name: Move ssl certificate to ensure we still find it

--- a/extension_config.cmake
+++ b/extension_config.cmake
@@ -6,6 +6,7 @@ duckdb_extension_load(unity_catalog
     LOAD_TESTS
 )
 
+# NOTE: replace with SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/../delta for local dev
 duckdb_extension_load(delta
     GIT_URL https://github.com/duckdb/duckdb-delta
     GIT_TAG 0e8892c8708329dddb618306e4f35eac0b0764bf

--- a/src/include/storage/uc_table_set.hpp
+++ b/src/include/storage/uc_table_set.hpp
@@ -27,6 +27,7 @@ public:
 	void RefreshCredentials(ClientContext &context);
 	void InternalAttach(ClientContext &context);
 	void InternalDetach(ClientContext &context);
+	void InternalCheckpoint(ClientContext &context, bool force);
 
 private:
 	string AttachedCatalogName() const;
@@ -59,6 +60,7 @@ public:
 	void Scan(ClientContext &context, const std::function<void(CatalogEntry &)> &callback);
 	void ClearEntries();
 	void OnDetach(ClientContext &context);
+	void Checkpoint(ClientContext &context, bool force);
 
 protected:
 	void LoadEntries(ClientContext &context);

--- a/src/storage/uc_table_set.cpp
+++ b/src/storage/uc_table_set.cpp
@@ -141,6 +141,25 @@ void UCTableSet::OnDetach(ClientContext &context) {
 	}
 }
 
+void TableInformation::InternalCheckpoint(ClientContext &context, bool force) {
+	// table_data is guaranteed non-null: InternalCheckpoint is only called from
+	// UCTableSet::Checkpoint, which calls LoadEntries first.
+	D_ASSERT(table_data);
+	RefreshCredentials(context);
+	InternalAttach(context);
+	internal_attached_database->GetTransactionManager().Checkpoint(context, force);
+}
+
+void UCTableSet::Checkpoint(ClientContext &context, bool force) {
+	if (!is_loaded) {
+		LoadEntries(context);
+		is_loaded = true;
+	}
+	for (auto &entry : tables) {
+		entry.second.InternalCheckpoint(context, force);
+	}
+}
+
 void UCTableSet::LoadEntries(ClientContext &context) {
 	auto &transaction = UCTransaction::Get(context, catalog);
 

--- a/src/storage/uc_transaction_manager.cpp
+++ b/src/storage/uc_transaction_manager.cpp
@@ -1,4 +1,5 @@
 #include "storage/uc_transaction_manager.hpp"
+#include "storage/uc_schema_entry.hpp"
 #include "duckdb/main/attached_database.hpp"
 
 namespace duckdb {
@@ -32,9 +33,10 @@ void UCTransactionManager::RollbackTransaction(Transaction &transaction) {
 }
 
 void UCTransactionManager::Checkpoint(ClientContext &context, bool force) {
-	// auto &transaction = UCTransaction::Get(context, db.GetCatalog());
-	//	auto &db = transaction.GetConnection();
-	//	db.Execute("CHECKPOINT");
+	unity_catalog.ScanSchemas(context, [&](SchemaCatalogEntry &entry) {
+		auto &schema = entry.Cast<UCSchemaEntry>();
+		schema.tables.Checkpoint(context, force);
+	});
 }
 
 } // namespace duckdb

--- a/test/sql/local_oss_unity_catalog/checkpoint.test
+++ b/test/sql/local_oss_unity_catalog/checkpoint.test
@@ -1,0 +1,62 @@
+# name: test/sql/local_oss_unity_catalog/checkpoint.test
+# description: test CHECKPOINT forwarding through UC to attached delta catalogs
+# group: [local_oss_unity_catalog]
+
+require parquet
+
+require unity_catalog
+
+require delta
+
+require httpfs
+
+require-env UC_TEST_SERVER_RUNNING
+
+require-env UC_TEST_DATA
+
+statement ok
+CREATE SECRET (
+    TYPE UNITY_CATALOG,
+    TOKEN 'not-used',
+    ENDPOINT 'http://127.0.0.1:8080',
+    AWS_REGION 'us-east-2'
+);
+
+statement ok
+ATTACH 'unity' AS my_catalog (TYPE UNITY_CATALOG, DEFAULT_SCHEMA 'default');
+
+# query to trigger attach
+query III
+FROM my_catalog.default.marksheet;
+----
+1	nWYHawtqUw	930
+2	uvOzzthsLV	166
+3	WIAehuXWkv	170
+4	wYCSvnJKTo	709
+5	VsslXsUIDZ	993
+6	ZLsACYYTFy	813
+7	BtDDvLeBpK	52
+8	YISVtrPfGr	8
+9	PBPJHDFjjC	45
+10	qbDuUJzJMO	756
+11	EjqqWoaLJn	712
+12	jpZLMdKXpn	847
+13	acpjQXpJCp	649
+14	nOKqHhRwao	133
+15	kxUUZEUoKv	398
+
+statement ok
+CHECKPOINT my_catalog;
+
+# Confirm presence of checkpoint files, also for other not-yet-attached tables
+query II rowsort
+SELECT parse_path(file)[-3], parse_path(file)[-1] FROM glob('${UC_TEST_DATA}/**/*checkpoint*');
+----
+marksheet	00000000000000000001.checkpoint.parquet
+marksheet	_last_checkpoint
+marksheet_uniform	00000000000000000001.checkpoint.parquet
+marksheet_uniform	_last_checkpoint
+numbers	00000000000000000000.checkpoint.parquet
+numbers	_last_checkpoint
+user_countries	00000000000000000000.checkpoint.parquet
+user_countries	_last_checkpoint


### PR DESCRIPTION
add checkpoint support to unity (via delta via FFI)

Checkpoints carry through existing per-table Delta APIs, which carry on
through the delta-kernel FFI.

Will force attachment of any tables not-yet-attached.

