### PR TITLE
fix: handle decimal types inside struct/map in UC type parser

### DIFF
--- a/src/uc_utils.cpp
+++ b/src/uc_utils.cpp
@@ -84,9 +84,9 @@ LogicalType UCUtils::TypeToLogicalType(ClientContext &context, const string &typ
 				size_t next_sep = cur;
 				// find the location of the next ',' ignoring nested commas
 				while (type_text[next_sep] != ',' || nested_opens > 0) {
-					if (type_text[next_sep] == '<') {
+					if (type_text[next_sep] == '<' || type_text[next_sep] == '(') {
 						nested_opens++;
-					} else if (type_text[next_sep] == '>') {
+					} else if (type_text[next_sep] == '>' || type_text[next_sep] == ')') {
 						nested_opens--;
 					}
 					next_sep++;
@@ -115,11 +115,11 @@ LogicalType UCUtils::TypeToLogicalType(ClientContext &context, const string &typ
 			auto nested_opens = 0;
 			for (;;) {
 				size_t next_sep = cur;
-				// find the location of the next ',' ignoring nested commas
+				// find the location of the next ',' ignoring nested commas and parentheses
 				while (type_text[next_sep] != ',' || nested_opens > 0) {
-					if (type_text[next_sep] == '<') {
+					if (type_text[next_sep] == '<' || type_text[next_sep] == '(') {
 						nested_opens++;
-					} else if (type_text[next_sep] == '>') {
+					} else if (type_text[next_sep] == '>' || type_text[next_sep] == ')') {
 						nested_opens--;
 					}
 					next_sep++;

--- a/src/uc_utils.cpp
+++ b/src/uc_utils.cpp
@@ -82,7 +82,7 @@ LogicalType UCUtils::TypeToLogicalType(ClientContext &context, const string &typ
 			auto nested_opens = 0;
 			for (;;) {
 				size_t next_sep = cur;
-				// find the location of the next ',' ignoring nested commas
+				// find the location of the next ',' ignoring nested commas and parentheses
 				while (type_text[next_sep] != ',' || nested_opens > 0) {
 					if (type_text[next_sep] == '<' || type_text[next_sep] == '(') {
 						nested_opens++;

--- a/test/sql/unit/type_parsing.test
+++ b/test/sql/unit/type_parsing.test
@@ -33,11 +33,11 @@ SELECT price.list_price FROM test_struct_decimal;
 2.000000000
 
 statement ok
-CREATE TABLE test_nested AS
+CREATE TABLE test_array_struct_decimal AS
 SELECT [{'bid_price': 1.5::DECIMAL(38,18), 'clear_price': 2.0::DECIMAL(38,18), 'ad_id': 'x'}] AS products;
 
 query I
-SELECT products[1].bid_price FROM test_nested;
+SELECT products[1].bid_price FROM test_array_struct_decimal;
 ----
 1.500000000000000000
 
@@ -73,7 +73,7 @@ statement ok
 DROP TABLE test_struct_decimal;
 
 statement ok
-DROP TABLE test_nested;
+DROP TABLE test_array_struct_decimal;
 
 statement ok
 DROP TABLE test_array_decimal;

--- a/test/sql/unit/type_parsing.test
+++ b/test/sql/unit/type_parsing.test
@@ -42,7 +42,24 @@ SELECT products[1].bid_price FROM test_nested;
 1.500000000000000000
 
 statement ok
+CREATE TABLE test_array_decimal AS
+SELECT [1.5::DECIMAL(38,18), 2.0::DECIMAL(38,18)] AS prices;
+
+query I
+SELECT prices[1] FROM test_array_decimal;
+----
+1.500000000000000000
+
+query I
+SELECT prices[2] FROM test_array_decimal;
+----
+2.000000000000000000
+
+statement ok
 DROP TABLE test_struct_decimal;
 
 statement ok
 DROP TABLE test_nested;
+
+statement ok
+DROP TABLE test_array_decimal;

--- a/test/sql/unit/type_parsing.test
+++ b/test/sql/unit/type_parsing.test
@@ -1,0 +1,48 @@
+# name: test/sql/unit/type_parsing.test
+# description: Test that UC type parsing handles decimal inside struct/map correctly
+# group: [unit]
+
+# This is an integration test that verifies DuckDB can handle the complex types
+# returned by the Unity Catalog API, particularly struct and map types containing
+# decimal(precision,scale) fields.
+#
+# The bug: the comma-splitting logic in struct/map type parsing only tracked
+# angle bracket nesting (<>), not parenthesis nesting (). This caused
+# "struct<price:decimal(38,18),name:string>" to be incorrectly split on the
+# comma inside decimal(38,18).
+
+require unity_catalog
+
+require delta
+
+# Verify DuckDB can create and query tables with the types that were previously
+# failing when read from Unity Catalog schema metadata.
+
+statement ok
+CREATE TABLE test_struct_decimal AS
+SELECT {'effective_price': 1.5::DECIMAL(38,9), 'unit': 'USD', 'list_price': 2.0::DECIMAL(38,9)} AS price;
+
+query I
+SELECT price.effective_price FROM test_struct_decimal;
+----
+1.500000000
+
+query I
+SELECT price.list_price FROM test_struct_decimal;
+----
+2.000000000
+
+statement ok
+CREATE TABLE test_nested AS
+SELECT [{'bid_price': 1.5::DECIMAL(38,18), 'clear_price': 2.0::DECIMAL(38,18), 'ad_id': 'x'}] AS products;
+
+query I
+SELECT products[1].bid_price FROM test_nested;
+----
+1.500000000000000000
+
+statement ok
+DROP TABLE test_struct_decimal;
+
+statement ok
+DROP TABLE test_nested;

--- a/test/sql/unit/type_parsing.test
+++ b/test/sql/unit/type_parsing.test
@@ -56,6 +56,20 @@ SELECT prices[2] FROM test_array_decimal;
 2.000000000000000000
 
 statement ok
+CREATE TABLE test_map_decimal AS
+SELECT MAP {'item_a': 1.5::DECIMAL(38,18), 'item_b': 2.0::DECIMAL(38,18)} AS prices;
+
+query I
+SELECT prices['item_a'] FROM test_map_decimal;
+----
+1.500000000000000000
+
+query I
+SELECT prices['item_b'] FROM test_map_decimal;
+----
+2.000000000000000000
+
+statement ok
 DROP TABLE test_struct_decimal;
 
 statement ok
@@ -63,3 +77,6 @@ DROP TABLE test_nested;
 
 statement ok
 DROP TABLE test_array_decimal;
+
+statement ok
+DROP TABLE test_map_decimal;


### PR DESCRIPTION
Hello, thanks for this extension.

I was poking around with our production table to see if our queries on databricks runtimes can run on duckDB.

## Summary

I have the error `Not implemented Error: Tried to fallback to unknown type for 'decimal(38'` when requesting any table. Even table without a `decimal(38,18)` type. 
I am running this extension and the `delta` extension from master with duckDB `v1.5.0`

## Root cause

When requesting a table, it will get all the tables in the schema and it happen that one of our table have a column of the type `struct<effective_price:decimal(38,9),unit:string>`. 
This type is making the struct parser in `UCUtils::TypeToLogicalType` to fail. When encountering a type like `decimal(38,18)` nested inside a struct or map, the parser would treat the comma between `38` and `18` as a field separator because it only tracked `<>` nesting depth, not `()` nesting depth.

## Fix

The fix adds `(` and `)` to the nesting depth tracking in both parsers. 
I have also added a test case for this type parsing covering a `decimal` inside struct, map and array.

This PR was generated with Claude Opus 4.6