### PR TITLE
fix test/sourcing: hand gen -> scripted now works

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,10 @@ DEFAULT_TEST_EXTENSION_DEPS=parquet;httpfs;tpch;tpcds
 
 #FULL_TEST_EXTENSION_DEPS=tpcds;tpch TODO: add
 
+# uv should work if created as suggested in venv: below, but allow overrides
+PYTHON_PIP=venv/bin/python3 -m pip
+PYTHON_BIN=venv/bin/python3
+
 ENV_DATABRICKS_CMD ?= scripts/run_databricks_env
 BUILD_DIR ?= ./build/release
 
@@ -16,18 +20,21 @@ BUILD_DIR ?= ./build/release
 include extension-ci-tools/makefiles/duckdb_extension.Makefile
 
 venv:
-	python3.12 --version | grep -q '^Python 3[.]12[.]'
-	python3.12 -m venv venv
-	./venv/bin/pip3 install -r scripts/databricks_data_gen/requirements.txt
+	# NOTE: must be py v3.12-3.14;
+	# if using uv locally, do:
+	# uv venv --python 3.14 && ln -s .venv venv && uv pip install -r scripts/databricks_data_gen/requirements.txt
+	python3 --version | grep -q '^Python 3[.]1[2-4][.]'
+	python3 -m venv venv
+	${PYTHON_PIP} install -r scripts/databricks_data_gen/requirements.txt
 
 # This is to (re)gen the test data in the remote databricks, this does not need to be rerun unless remote data needs refreshing
 # Requires the same env variables from the write tests
 test_data_prepare: venv
 	for f in scripts/databricks_data_gen/custom_data_sources/*.sql; do \
-		./venv/bin/python3 scripts/databricks_data_gen/generate_databricks_test_data.py from-custom-sql $$f duckdb_testing.main; \
+		${PYTHON_BIN} scripts/databricks_data_gen/generate_databricks_test_data.py from-custom-sql $$f duckdb_testing.main; \
 	done
-	./venv/bin/python3 scripts/databricks_data_gen/generate_databricks_test_data.py from-duckdb-sql scripts/databricks_data_gen/duckdb_data_sources/tpcds_sf0_01.sql duckdb_testing.tpcds_sf0_01
-	./venv/bin/python3 scripts/databricks_data_gen/generate_databricks_test_data.py from-duckdb-sql scripts/databricks_data_gen/duckdb_data_sources/tpch_sf0_01.sql duckdb_testing.tpch_sf0_01
+	${PYTHON_BIN} scripts/databricks_data_gen/generate_databricks_test_data.py from-duckdb-sql scripts/databricks_data_gen/duckdb_data_sources/tpcds_sf0_01.sql duckdb_testing.tpcds_sf0_01
+	${PYTHON_BIN} scripts/databricks_data_gen/generate_databricks_test_data.py from-duckdb-sql scripts/databricks_data_gen/duckdb_data_sources/tpch_sf0_01.sql duckdb_testing.tpch_sf0_01
 
 ################################################
 # Databricks Tests
@@ -44,21 +51,19 @@ run_databricks_tests:
 # These tests will automatically load some data into a fresh schema in databricks, then allows you to run some tests on it
 # NOTE: Easiest way is to just do make `run_write_tests` which runs all steps
 
-# TODO: test data in `source` schema is currently hand generated, this should be cleaned up
-
 # Before running this, ensure your env is configured:
 #    >   . scripts/run_databricks_env
 
 # Prepare the main write test files by copying the tables from the `source` schema to the `{DATABRICKS_WRITE_TEST_SCHEMA}` schema
 write_tests_prepare: venv
-	./venv/bin/python3 scripts/databricks_data_gen/generate_databricks_test_data.py copy ${DATABRICKS_WRITE_TEST_CATALOG}.source ${DATABRICKS_WRITE_TEST_CATALOG}.${DATABRICKS_WRITE_TEST_SCHEMA}
-	./venv/bin/python3 scripts/databricks_data_gen/generate_databricks_test_data.py copy ${DATABRICKS_WRITE_TEST_CATALOG}.source ${DATABRICKS_WRITE_TEST_CATALOG}.${DATABRICKS_WRITE_TEST_SCHEMA} --catalog-managed
+	${PYTHON_BIN} scripts/databricks_data_gen/generate_databricks_test_data.py copy ${DATABRICKS_WRITE_TEST_CATALOG}.source ${DATABRICKS_WRITE_TEST_CATALOG}.${DATABRICKS_WRITE_TEST_SCHEMA}
+	${PYTHON_BIN} scripts/databricks_data_gen/generate_databricks_test_data.py copy ${DATABRICKS_WRITE_TEST_CATALOG}.source ${DATABRICKS_WRITE_TEST_CATALOG}.${DATABRICKS_WRITE_TEST_SCHEMA} --catalog-managed
 
 write_tests_run:
 	$(BUILD_DIR)/test/unittest "test/sql/databricks/write_tests/*"
 
 write_tests_cleanup:
-	./venv/bin/python3 scripts/databricks_data_gen/clean_test_data.py ${DATABRICKS_WRITE_TEST_CATALOG}.${DATABRICKS_WRITE_TEST_SCHEMA}
+	${PYTHON_BIN} scripts/databricks_data_gen/clean_test_data.py ${DATABRICKS_WRITE_TEST_CATALOG}.${DATABRICKS_WRITE_TEST_SCHEMA}
 
 # - fetches credentials from 1password
 # - generates new schema name

--- a/test/sql/databricks/write_tests/write.test
+++ b/test/sql/databricks/write_tests/write.test
@@ -28,7 +28,7 @@ set ignore_error_messages
 
 statement ok
 CREATE SECRET (
-    TYPE UC,
+    TYPE unity_catalog,
     TOKEN '${DATABRICKS_TOKEN}',
     ENDPOINT '${DATABRICKS_ENDPOINT}',
     AWS_REGION '${DATABRICKS_REGION}'
@@ -36,29 +36,29 @@ CREATE SECRET (
 
 # Attach to databricks through the unity catalog API
 statement ok
-ATTACH '${DATABRICKS_WRITE_TEST_CATALOG}' as databricks_catalog (TYPE UNITY_CATALOG, DEFAULT_SCHEMA '${DATABRICKS_WRITE_TEST_SCHEMA}');
+ATTACH '${DATABRICKS_WRITE_TEST_CATALOG}' AS databricks_catalog (TYPE unity_catalog, DEFAULT_SCHEMA '${DATABRICKS_WRITE_TEST_SCHEMA}');
 
 statement ok
 USE databricks_catalog;
 
-query II
-SELECT * FROM simple_table ORDER BY col1
+query I
+SELECT * FROM simple_table ORDER BY id;
 ----
-0	value-0
-1	value-1
-2	value-2
-3	value-3
-4	value-4
+1
+2
+3
+4
+5
 
 statement ok
-INSERT INTO simple_table VALUES (5, 'value-5');
+INSERT INTO simple_table VALUES (10);
 
-query II
-SELECT * FROM simple_table ORDER BY col1
+query I
+SELECT * FROM simple_table ORDER BY id;
 ----
-0	value-0
-1	value-1
-2	value-2
-3	value-3
-4	value-4
-5	value-5
+1
+2
+3
+4
+5
+10

--- a/test/sql/databricks/write_tests/write_catalog_managed.test
+++ b/test/sql/databricks/write_tests/write_catalog_managed.test
@@ -36,46 +36,46 @@ CREATE SECRET (
 
 # Attach to databricks through the unity catalog API
 statement ok
-ATTACH '${DATABRICKS_WRITE_TEST_CATALOG}' as databricks_catalog (TYPE UNITY_CATALOG, DEFAULT_SCHEMA '${DATABRICKS_WRITE_TEST_SCHEMA}');
+ATTACH '${DATABRICKS_WRITE_TEST_CATALOG}' AS databricks_catalog (TYPE unity_catalog, DEFAULT_SCHEMA '${DATABRICKS_WRITE_TEST_SCHEMA}');
 
 statement ok
 USE databricks_catalog;
 
 statement ok
-call enable_logging(level='debug');
+CALL enable_logging(level='debug');
 
 statement ok
 SET VARIABLE table_path = (FROM databricks_catalog.table_data_path('simple_table_catalog_managed'));
 
-query II
-SELECT * FROM simple_table_catalog_managed ORDER BY col1
+query I
+SELECT * FROM simple_table_catalog_managed ORDER BY id;
 ----
-0	value-0
-1	value-1
-2	value-2
-3	value-3
-4	value-4
+1
+2
+3
+4
+5
 
 statement ok
-INSERT INTO simple_table_catalog_managed VALUES (5, 'value-5');
+INSERT INTO simple_table_catalog_managed VALUES (10);
 
 statement ok
-INSERT INTO simple_table_catalog_managed VALUES (6, 'value-6');
+INSERT INTO simple_table_catalog_managed VALUES (11);
 
-query II
-SELECT * FROM simple_table_catalog_managed ORDER BY col1
+query I
+SELECT * FROM simple_table_catalog_managed ORDER BY id
 ----
-0	value-0
-1	value-1
-2	value-2
-3	value-3
-4	value-4
-5	value-5
-6	value-6
+1
+2
+3
+4
+5
+10
+11
 
 # List the staged commits to the table
 query I
-SELECT parse_filename(file)[0:21] as f FROM GLOB(getvariable('table_path') || '/_delta_log/_staged_commits/**/*') order by f;
+SELECT parse_filename(file)[0:21] AS f FROM GLOB(getvariable('table_path') || '/_delta_log/_staged_commits/**/*') ORDER BY f;
 ----
 00000000000000000001.
 00000000000000000002.


### PR DESCRIPTION
Previously tests relied on hand-generated source tables. Those have changes, and tests broke. Update tests to match existing sources, and slightly tweak test runner Makefile for flexibility with uv.

(I already manually updated source tables to match.)