### PR TITLE
fix duckdb handling of staged/ratified commits in managed tables

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -14,36 +14,36 @@ concurrency:
 jobs:
   duckdb-stable-build:
     name: Build extension binaries
-    uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@v1.5.0
+    uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@v1.5-variegata
     with:
       extension_name: &ext_name unity_catalog
-      duckdb_version: &duckdb_ref v1.5.1
-      ci_tools_version: &ci_tools_ref v1.5.0
-      exclude_archs: 'wasm_mvp;wasm_eh;wasm_threads;windows_amd64_mingw;windows_amd64;linux_arm64;linux_amd64_musl'
+      duckdb_version: &duckdb_ref v1.5.3
+      ci_tools_version: &ci_tools_ref v1.5-variegata
+      exclude_archs: wasm_mvp;wasm_eh;wasm_threads;windows_amd64_mingw;windows_amd64;linux_arm64;linux_amd64_musl
       enable_rust: true
       rust_logs: true
-      use_merged_vcpkg_manifest: '1'
+      use_merged_vcpkg_manifest: 1
       reduced_ci_mode: ${{ github.event_name == 'pull_request' && 'enabled' || 'disabled'}}
 
   duckdb-stable-deploy:
     name: Deploy extension binaries
     needs: duckdb-stable-build
-    uses: duckdb/extension-ci-tools/.github/workflows/_extension_deploy.yml@v1.5.0
+    uses: duckdb/extension-ci-tools/.github/workflows/_extension_deploy.yml@v1.5-variegata
     secrets: inherit
     with:
       extension_name: *ext_name
       duckdb_version: *duckdb_ref
       ci_tools_version: *ci_tools_ref
-      exclude_archs: 'wasm_mvp;wasm_eh;wasm_threads;windows_amd64_mingw;windows_amd64;linux_arm64;linux_amd64_musl'
+      exclude_archs: wasm_mvp;wasm_eh;wasm_threads;windows_amd64_mingw;windows_amd64;linux_arm64;linux_amd64_musl
       deploy_latest: ${{ startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' }}
       reduced_ci_mode: ${{ github.event_name == 'pull_request' && 'enabled' || 'disabled'}}
 
   code-quality-check:
     name: Code Quality Check
-    uses: duckdb/extension-ci-tools/.github/workflows/_extension_code_quality.yml@v1.5.0
+    uses: duckdb/extension-ci-tools/.github/workflows/_extension_code_quality.yml@v1.5-variegata
     with:
       extension_name: *ext_name
       duckdb_version: *duckdb_ref
       ci_tools_version: *ci_tools_ref
       format_checks: format
-      extra_toolchains: 'python3'
+      extra_toolchains: python3

--- a/Makefile
+++ b/Makefile
@@ -29,10 +29,14 @@ venv:
 
 # This is to (re)gen the test data in the remote databricks, this does not need to be rerun unless remote data needs refreshing
 # Requires the same env variables from the write tests
+# NOTE: requires databricks env IN PLACE, and $(BUILD_DIR)/duckdb with UC+Delta extensions loaded
 test_data_prepare: venv
 	for f in scripts/databricks_data_gen/custom_data_sources/*.sql; do \
 		${PYTHON_BIN} scripts/databricks_data_gen/generate_databricks_test_data.py from-custom-sql $$f duckdb_testing.main; \
 	done
+	# id_day_managed_duckdb: loop above created empty catalog-managed table via Spark; now insert data via DuckDB UC extension
+	# TODO: update gen+table structures to use this for all simple tables; it's currently 1-off for this specific bug fix
+	bash -c 'envsubst < scripts/databricks_data_gen/duckdb_data_sources/insert_id_day_managed_duckdb.sql | $(BUILD_DIR)/duckdb'
 	${PYTHON_BIN} scripts/databricks_data_gen/generate_databricks_test_data.py from-duckdb-sql scripts/databricks_data_gen/duckdb_data_sources/tpcds_sf0_01.sql duckdb_testing.tpcds_sf0_01
 	${PYTHON_BIN} scripts/databricks_data_gen/generate_databricks_test_data.py from-duckdb-sql scripts/databricks_data_gen/duckdb_data_sources/tpch_sf0_01.sql duckdb_testing.tpch_sf0_01
 

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,10 @@ DEFAULT_TEST_EXTENSION_DEPS=parquet;httpfs;tpch;tpcds
 
 #FULL_TEST_EXTENSION_DEPS=tpcds;tpch TODO: add
 
+# uv should work if created as suggested in venv: below, but allow overrides
+PYTHON_PIP=venv/bin/python3 -m pip
+PYTHON_BIN=venv/bin/python3
+
 ENV_DATABRICKS_CMD ?= scripts/run_databricks_env
 BUILD_DIR ?= ./build/release
 
@@ -16,18 +20,21 @@ BUILD_DIR ?= ./build/release
 include extension-ci-tools/makefiles/duckdb_extension.Makefile
 
 venv:
-	python3.12 --version | grep -q '^Python 3[.]12[.]'
-	python3.12 -m venv venv
-	./venv/bin/pip3 install -r scripts/databricks_data_gen/requirements.txt
+	# NOTE: must be py v3.12-3.14;
+	# if using uv locally, do:
+	# uv venv --python 3.14 && ln -s .venv venv && uv pip install -r scripts/databricks_data_gen/requirements.txt
+	python3 --version | grep -q '^Python 3[.]1[2-4][.]'
+	python3 -m venv venv
+	${PYTHON_PIP} install -r scripts/databricks_data_gen/requirements.txt
 
 # This is to (re)gen the test data in the remote databricks, this does not need to be rerun unless remote data needs refreshing
 # Requires the same env variables from the write tests
 test_data_prepare: venv
 	for f in scripts/databricks_data_gen/custom_data_sources/*.sql; do \
-		./venv/bin/python3 scripts/databricks_data_gen/generate_databricks_test_data.py from-custom-sql $$f duckdb_testing.main; \
+		${PYTHON_BIN} scripts/databricks_data_gen/generate_databricks_test_data.py from-custom-sql $$f duckdb_testing.main; \
 	done
-	./venv/bin/python3 scripts/databricks_data_gen/generate_databricks_test_data.py from-duckdb-sql scripts/databricks_data_gen/duckdb_data_sources/tpcds_sf0_01.sql duckdb_testing.tpcds_sf0_01
-	./venv/bin/python3 scripts/databricks_data_gen/generate_databricks_test_data.py from-duckdb-sql scripts/databricks_data_gen/duckdb_data_sources/tpch_sf0_01.sql duckdb_testing.tpch_sf0_01
+	${PYTHON_BIN} scripts/databricks_data_gen/generate_databricks_test_data.py from-duckdb-sql scripts/databricks_data_gen/duckdb_data_sources/tpcds_sf0_01.sql duckdb_testing.tpcds_sf0_01
+	${PYTHON_BIN} scripts/databricks_data_gen/generate_databricks_test_data.py from-duckdb-sql scripts/databricks_data_gen/duckdb_data_sources/tpch_sf0_01.sql duckdb_testing.tpch_sf0_01
 
 ################################################
 # Databricks Tests
@@ -44,21 +51,19 @@ run_databricks_tests:
 # These tests will automatically load some data into a fresh schema in databricks, then allows you to run some tests on it
 # NOTE: Easiest way is to just do make `run_write_tests` which runs all steps
 
-# TODO: test data in `source` schema is currently hand generated, this should be cleaned up
-
 # Before running this, ensure your env is configured:
 #    >   . scripts/run_databricks_env
 
 # Prepare the main write test files by copying the tables from the `source` schema to the `{DATABRICKS_WRITE_TEST_SCHEMA}` schema
 write_tests_prepare: venv
-	./venv/bin/python3 scripts/databricks_data_gen/generate_databricks_test_data.py copy ${DATABRICKS_WRITE_TEST_CATALOG}.source ${DATABRICKS_WRITE_TEST_CATALOG}.${DATABRICKS_WRITE_TEST_SCHEMA}
-	./venv/bin/python3 scripts/databricks_data_gen/generate_databricks_test_data.py copy ${DATABRICKS_WRITE_TEST_CATALOG}.source ${DATABRICKS_WRITE_TEST_CATALOG}.${DATABRICKS_WRITE_TEST_SCHEMA} --catalog-managed
+	${PYTHON_BIN} scripts/databricks_data_gen/generate_databricks_test_data.py copy ${DATABRICKS_WRITE_TEST_CATALOG}.source ${DATABRICKS_WRITE_TEST_CATALOG}.${DATABRICKS_WRITE_TEST_SCHEMA}
+	${PYTHON_BIN} scripts/databricks_data_gen/generate_databricks_test_data.py copy ${DATABRICKS_WRITE_TEST_CATALOG}.source ${DATABRICKS_WRITE_TEST_CATALOG}.${DATABRICKS_WRITE_TEST_SCHEMA} --catalog-managed
 
 write_tests_run:
 	$(BUILD_DIR)/test/unittest "test/sql/databricks/write_tests/*"
 
 write_tests_cleanup:
-	./venv/bin/python3 scripts/databricks_data_gen/clean_test_data.py ${DATABRICKS_WRITE_TEST_CATALOG}.${DATABRICKS_WRITE_TEST_SCHEMA}
+	${PYTHON_BIN} scripts/databricks_data_gen/clean_test_data.py ${DATABRICKS_WRITE_TEST_CATALOG}.${DATABRICKS_WRITE_TEST_SCHEMA}
 
 # - fetches credentials from 1password
 # - generates new schema name

--- a/extension_config.cmake
+++ b/extension_config.cmake
@@ -8,7 +8,5 @@ duckdb_extension_load(unity_catalog
 
 # NOTE: replace with SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/../delta for local dev
 duckdb_extension_load(delta
-    GIT_URL https://github.com/duckdb/duckdb-delta
-    GIT_TAG 4cfde24f98b5128c46a7a06a67e292024f920b1e
-    SUBMODULES extension-ci-tools
+    SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/../delta
 )

--- a/extension_config.cmake
+++ b/extension_config.cmake
@@ -8,7 +8,7 @@ duckdb_extension_load(unity_catalog
 
 # NOTE: replace with SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/../delta for local dev
 duckdb_extension_load(delta
-    GIT_URL https://github.com/benfleis/duckdb-delta
-    GIT_TAG 0a77c6ec43a7febff36580960e5c1a8739d85420
+    GIT_URL https://github.com/duckdb/duckdb-delta
+    GIT_TAG 45c40878601b54b4188b09e08732fe0d576ad222
     SUBMODULES extension-ci-tools
 )

--- a/extension_config.cmake
+++ b/extension_config.cmake
@@ -8,5 +8,7 @@ duckdb_extension_load(unity_catalog
 
 # NOTE: replace with SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/../delta for local dev
 duckdb_extension_load(delta
-    SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/../delta
+    GIT_URL https://github.com/benfleis/duckdb-delta
+    GIT_TAG 0a77c6ec43a7febff36580960e5c1a8739d85420
+    SUBMODULES extension-ci-tools
 )

--- a/scripts/databricks_data_gen/custom_data_sources/id_day_managed_duckdb.sql
+++ b/scripts/databricks_data_gen/custom_data_sources/id_day_managed_duckdb.sql
@@ -1,0 +1,14 @@
+-- id_day_managed_duckdb: catalog-managed table, structure created by Spark, data inserted by DuckDB.
+-- The Spark CREATE creates the catalog-managed table (staged commits). DuckDB inserts data via
+-- the preview API, which promotes commits to _delta_log/ (not staged). This table should be
+-- readable on both fixed and unfixed builds (DuckDB-written commits don't require max_catalog_version).
+-- Contrast with id_day_managed_spark: same schema, same rows, but write path differs.
+-- Generate: python scripts/databricks_data_gen/generate_databricks_test_data.py from-custom-sql \
+--             scripts/databricks_data_gen/custom_data_sources/id_day_managed_duckdb.sql duckdb_testing.main
+-- Data is inserted separately by the test_data_prepare Makefile target via DuckDB UC extension.
+CREATE OR REPLACE TABLE {table_name}
+    TBLPROPERTIES (
+        'delta.feature.catalogManaged' = 'supported',
+        'delta.enableRowTracking' = 'false'
+    )
+    AS SELECT id, CAST(NULL AS STRING) AS day FROM range(1, 1) AS t(id) WHERE 1=0

--- a/scripts/databricks_data_gen/custom_data_sources/id_day_managed_spark.sql
+++ b/scripts/databricks_data_gen/custom_data_sources/id_day_managed_spark.sql
@@ -1,0 +1,18 @@
+-- id_day_managed_spark: catalog-managed table, all data written by Spark (staged commits).
+-- Used to verify that max_catalog_version is correctly passed to the Delta kernel so that
+-- staged commits are visible. On an unfixed build this fails with:
+--   "Staged commits in log_tail require max_catalog_version to be set"
+-- Same schema as scan_plan_days_managed: id INT, day VARCHAR, 50 rows across 5 INSERTs.
+-- Generate: python scripts/databricks_data_gen/generate_databricks_test_data.py from-custom-sql \
+--             scripts/databricks_data_gen/custom_data_sources/id_day_managed_spark.sql duckdb_testing.main
+CREATE OR REPLACE TABLE {table_name}
+    TBLPROPERTIES (
+        'delta.feature.catalogManaged' = 'supported',
+        'delta.enableRowTracking' = 'false'
+    )
+    AS SELECT id, 'Mon' AS day FROM range(1, 11) AS t(id);
+
+INSERT INTO {table_name} SELECT id, 'Tue' AS day FROM range(11, 21) AS t(id);
+INSERT INTO {table_name} SELECT id, 'Wed' AS day FROM range(21, 31) AS t(id);
+INSERT INTO {table_name} SELECT id, 'Thu' AS day FROM range(31, 41) AS t(id);
+INSERT INTO {table_name} SELECT id, 'Fri' AS day FROM range(41, 51) AS t(id)

--- a/scripts/databricks_data_gen/duckdb_data_sources/insert_id_day_managed_duckdb.sql
+++ b/scripts/databricks_data_gen/duckdb_data_sources/insert_id_day_managed_duckdb.sql
@@ -1,0 +1,16 @@
+-- Inserts data into id_day_managed_duckdb via the DuckDB UC extension.
+-- This uses the preview API write path, which promotes commits to _delta_log/
+-- (not staged), in contrast to Spark-written id_day_managed_spark.
+-- Run via test_data_prepare after id_day_managed_duckdb table has been created by Spark.
+CREATE SECRET (TYPE UNITY_CATALOG, TOKEN '${DATABRICKS_TOKEN}', ENDPOINT '${DATABRICKS_ENDPOINT}', AWS_REGION '${DATABRICKS_REGION}');
+ATTACH 'duckdb_testing' (TYPE UNITY_CATALOG, DEFAULT_SCHEMA 'main');
+INSERT INTO duckdb_testing.main.id_day_managed_duckdb
+SELECT id,
+    CASE ((id-1)%5)
+        WHEN 0 THEN 'Mon'
+        WHEN 1 THEN 'Tue'
+        WHEN 2 THEN 'Wed'
+        WHEN 3 THEN 'Thu'
+        ELSE 'Fri'
+    END AS day
+FROM range(1, 51) t(id);

--- a/src/include/storage/uc_table_set.hpp
+++ b/src/include/storage/uc_table_set.hpp
@@ -29,7 +29,6 @@ public:
 	void InternalDetach(ClientContext &context, const lock_guard<mutex> &_attach_lock);
 	void InternalCheckpoint(ClientContext &context, bool force);
 	bool IsCCV2() const;
-	Value BuildLogTail(ClientContext &context);
 	void MarkDirty();
 
 private:

--- a/src/storage/uc_table_set.cpp
+++ b/src/storage/uc_table_set.cpp
@@ -142,18 +142,14 @@ bool TableInformation::IsCCV2() const {
 	return it != table_data->properties.end() && it->second == "supported";
 }
 
-Value TableInformation::BuildLogTail(ClientContext &context) {
-	auto &uc_catalog = catalog.Cast<UnityCatalog>();
-	auto commits =
-	    UCAPI::GetCommits(context, table_data->table_id, table_data->storage_location, uc_catalog.credentials);
-
+static Value BuildLogTailFromCommits(const UCAPICommitsResult &commits, const string &storage_location) {
 	vector<Value> commit_values;
 	for (const auto &commit : commits.commits) {
 		child_list_t<Value> commit_struct;
 		commit_struct.push_back(make_pair("version", Value::BIGINT(commit.version)));
 		commit_struct.push_back(make_pair("timestamp", Value::BIGINT(commit.timestamp)));
-		commit_struct.push_back(make_pair(
-		    "file_name", Value(table_data->storage_location + "/_delta_log/_staged_commits/" + commit.file_name)));
+		commit_struct.push_back(
+		    make_pair("file_name", Value(storage_location + "/_delta_log/_staged_commits/" + commit.file_name)));
 		commit_struct.push_back(make_pair("file_size", Value::BIGINT(commit.file_size)));
 		commit_struct.push_back(
 		    make_pair("file_modification_timestamp", Value::BIGINT(commit.file_modification_timestamp)));
@@ -189,12 +185,15 @@ void TableInformation::InternalAttach(ClientContext &context) {
 	info.path = table_data->storage_location;
 
 	if (IsCCV2()) {
-		auto log_tail = BuildLogTail(context);
+		auto &uc_catalog = catalog.Cast<UnityCatalog>();
+		auto commits =
+		    UCAPI::GetCommits(context, table_data->table_id, table_data->storage_location, uc_catalog.credentials);
 		info.options["parent_catalog"] = Value(catalog.GetName());
 		info.options["parent_catalog_schema"] = Value(schema.name);
 		info.options["parent_commit"] = Value(true);
-		if (!log_tail.IsNull()) {
-			info.options["log_tail"] = log_tail;
+		info.options["max_catalog_version"] = Value::BIGINT(commits.latest_table_version);
+		if (!commits.commits.empty()) {
+			info.options["log_tail"] = BuildLogTailFromCommits(commits, table_data->storage_location);
 		}
 	}
 

--- a/test/sql/databricks/catalog_managed_delta_read.test
+++ b/test/sql/databricks/catalog_managed_delta_read.test
@@ -1,0 +1,63 @@
+# name: test/sql/databricks/catalog_managed_delta_read.test
+# description: Reads catalog-managed tables via the Delta path to verify max_catalog_version is passed to the kernel.
+# group: [databricks]
+
+#
+# id_day_managed_spark: catalog-managed, all commits written by Spark (staged commits).
+#   Fails on main with: "Staged commits in log_tail require max_catalog_version to be set"
+#
+# id_day_managed_duckdb: catalog-managed, structure created by Spark, data inserted by DuckDB via preview API.
+#   DuckDB-written commits are promoted to _delta_log/ (not staged), so this works on main.
+
+require parquet
+
+require unity_catalog
+
+require delta
+
+require httpfs
+
+require-env DATABRICKS_TOKEN
+
+require-env DATABRICKS_ENDPOINT
+
+require-env DATABRICKS_REGION
+
+statement ok
+CREATE SECRET (
+    TYPE UNITY_CATALOG,
+    TOKEN '${DATABRICKS_TOKEN}',
+    ENDPOINT '${DATABRICKS_ENDPOINT}',
+    AWS_REGION '${DATABRICKS_REGION}'
+);
+
+statement ok
+ATTACH 'duckdb_testing' (TYPE UNITY_CATALOG, READ_ONLY, DEFAULT_SCHEMA 'main');
+
+# -----------------------------------------------------------------------------
+# id_day_managed_spark — staged commits (Spark write path), needs max_catalog_version
+#
+
+query I
+SELECT count(*) FROM duckdb_testing.main.id_day_managed_spark;
+----
+50
+
+query I
+SELECT count(*) FROM duckdb_testing.main.id_day_managed_spark WHERE day = 'Mon';
+----
+10
+
+# -----------------------------------------------------------------------------
+# id_day_managed_duckdb — DuckDB-inserted data (preview API, commits promoted to _delta_log)
+#
+
+query I
+SELECT count(*) FROM duckdb_testing.main.id_day_managed_duckdb;
+----
+50
+
+query I
+SELECT count(*) FROM duckdb_testing.main.id_day_managed_duckdb WHERE day = 'Mon';
+----
+10

--- a/test/sql/databricks/write_tests/write.test
+++ b/test/sql/databricks/write_tests/write.test
@@ -28,7 +28,7 @@ set ignore_error_messages
 
 statement ok
 CREATE SECRET (
-    TYPE UC,
+    TYPE unity_catalog,
     TOKEN '${DATABRICKS_TOKEN}',
     ENDPOINT '${DATABRICKS_ENDPOINT}',
     AWS_REGION '${DATABRICKS_REGION}'
@@ -36,29 +36,29 @@ CREATE SECRET (
 
 # Attach to databricks through the unity catalog API
 statement ok
-ATTACH '${DATABRICKS_WRITE_TEST_CATALOG}' as databricks_catalog (TYPE UNITY_CATALOG, DEFAULT_SCHEMA '${DATABRICKS_WRITE_TEST_SCHEMA}');
+ATTACH '${DATABRICKS_WRITE_TEST_CATALOG}' AS databricks_catalog (TYPE unity_catalog, DEFAULT_SCHEMA '${DATABRICKS_WRITE_TEST_SCHEMA}');
 
 statement ok
 USE databricks_catalog;
 
-query II
-SELECT * FROM simple_table ORDER BY col1
+query I
+SELECT * FROM simple_table ORDER BY id;
 ----
-0	value-0
-1	value-1
-2	value-2
-3	value-3
-4	value-4
+1
+2
+3
+4
+5
 
 statement ok
-INSERT INTO simple_table VALUES (5, 'value-5');
+INSERT INTO simple_table VALUES (10);
 
-query II
-SELECT * FROM simple_table ORDER BY col1
+query I
+SELECT * FROM simple_table ORDER BY id;
 ----
-0	value-0
-1	value-1
-2	value-2
-3	value-3
-4	value-4
-5	value-5
+1
+2
+3
+4
+5
+10

--- a/test/sql/databricks/write_tests/write_catalog_managed.test
+++ b/test/sql/databricks/write_tests/write_catalog_managed.test
@@ -36,46 +36,46 @@ CREATE SECRET (
 
 # Attach to databricks through the unity catalog API
 statement ok
-ATTACH '${DATABRICKS_WRITE_TEST_CATALOG}' as databricks_catalog (TYPE UNITY_CATALOG, DEFAULT_SCHEMA '${DATABRICKS_WRITE_TEST_SCHEMA}');
+ATTACH '${DATABRICKS_WRITE_TEST_CATALOG}' AS databricks_catalog (TYPE unity_catalog, DEFAULT_SCHEMA '${DATABRICKS_WRITE_TEST_SCHEMA}');
 
 statement ok
 USE databricks_catalog;
 
 statement ok
-call enable_logging(level='debug');
+CALL enable_logging(level='debug');
 
 statement ok
 SET VARIABLE table_path = (FROM databricks_catalog.table_data_path('simple_table_catalog_managed'));
 
-query II
-SELECT * FROM simple_table_catalog_managed ORDER BY col1
+query I
+SELECT * FROM simple_table_catalog_managed ORDER BY id;
 ----
-0	value-0
-1	value-1
-2	value-2
-3	value-3
-4	value-4
+1
+2
+3
+4
+5
 
 statement ok
-INSERT INTO simple_table_catalog_managed VALUES (5, 'value-5');
+INSERT INTO simple_table_catalog_managed VALUES (10);
 
 statement ok
-INSERT INTO simple_table_catalog_managed VALUES (6, 'value-6');
+INSERT INTO simple_table_catalog_managed VALUES (11);
 
-query II
-SELECT * FROM simple_table_catalog_managed ORDER BY col1
+query I
+SELECT * FROM simple_table_catalog_managed ORDER BY id
 ----
-0	value-0
-1	value-1
-2	value-2
-3	value-3
-4	value-4
-5	value-5
-6	value-6
+1
+2
+3
+4
+5
+10
+11
 
 # List the staged commits to the table
 query I
-SELECT parse_filename(file)[0:21] as f FROM GLOB(getvariable('table_path') || '/_delta_log/_staged_commits/**/*') order by f;
+SELECT parse_filename(file)[0:21] AS f FROM GLOB(getvariable('table_path') || '/_delta_log/_staged_commits/**/*') ORDER BY f;
 ----
 00000000000000000001.
 00000000000000000002.


### PR DESCRIPTION
fix duckdb handling of ratified commits in managed tables

In order to handle visible ratified commits within a UC managed table,
delta-kernel requires the `max_catalog_version` parameter. Get this,
and pass it through to delta+kernel. Depends on duckdb/duckdb-delta#319

New test validates against both spark- and duckdb- committed tables.
