### PR TITLE
Fix: unknown type variant

### DIFF
--- a/scripts/databricks_data_gen/custom_data_sources/variant_table.sql
+++ b/scripts/databricks_data_gen/custom_data_sources/variant_table.sql
@@ -1,0 +1,6 @@
+CREATE OR REPLACE TABLE {table_name}
+LOCATION '{location}'
+AS SELECT
+    id,
+    parse_json('{"value": ' || CAST(id AS STRING) || '}')::variant AS data
+FROM range(1, 6) AS t(id)

--- a/src/uc_utils.cpp
+++ b/src/uc_utils.cpp
@@ -50,6 +50,8 @@ LogicalType UCUtils::TypeToLogicalType(ClientContext &context, const string &typ
 		return LogicalType::BOOLEAN;
 	} else if (type_text == "timestamp") {
 		return LogicalType::TIMESTAMP_TZ;
+	} else if (type_text == "variant") {
+		return LogicalType::VARIANT();
 	} else if (type_text == "binary") {
 		return LogicalType::BLOB;
 	} else if (type_text == "date") {

--- a/test/sql/databricks/variant.test
+++ b/test/sql/databricks/variant.test
@@ -1,0 +1,37 @@
+# name: test/sql/databricks/variant.test
+# description: test reading tables with variant columns
+# group: [databricks]
+
+require parquet
+
+require unity_catalog
+
+require delta
+
+require httpfs
+
+require-env DATABRICKS_TOKEN
+
+require-env DATABRICKS_ENDPOINT
+
+require-env DATABRICKS_REGION
+
+statement ok
+CREATE SECRET (
+    TYPE UNITY_CATALOG,
+    TOKEN '${DATABRICKS_TOKEN}',
+    ENDPOINT '${DATABRICKS_ENDPOINT}',
+    AWS_REGION '${DATABRICKS_REGION}'
+);
+
+statement ok
+ATTACH 'duckdb_testing' (TYPE UNITY_CATALOG, READ_ONLY, DEFAULT_SCHEMA 'main');
+
+query II
+SELECT id, data FROM duckdb_testing.main.variant_table ORDER BY id;
+----
+1	{"value": 1}
+2	{"value": 2}
+3	{"value": 3}
+4	{"value": 4}
+5	{"value": 5}


### PR DESCRIPTION
## Summary

When querying tables that have a `variant` column, the following error is raised:

```
Not implemented Error:
Tried to fallback to unknown type for 'variant'
```

The fix maps `variant` to DuckDB's `LogicalType::VARIANT()`.

Fixes #83

Related to #82 (same pattern, for `timestamp_ntz`).

## Test plan

- Added `scripts/databricks_data_gen/custom_data_sources/variant_table.sql` to generate a test table with a variant column on Databricks
- Added `test/sql/databricks/variant.test` to verify reading such a table works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)