### PR TITLE
fix commit backfilling

### DIFF
--- a/src/functions/uc_delta_ccv2_commit.cpp
+++ b/src/functions/uc_delta_ccv2_commit.cpp
@@ -46,8 +46,12 @@ void UCDeltaCCV2CommitExecute(ClientContext &context, TableFunctionInput &data_p
 	// Get relative path
 	string commit_file_name = commit_file_path.substr(commit_file_path.find_last_of("/\\") + 1);
 
+	// Queue backfill for next InternalAttach — S3 credential lookup requires a catalog transaction
+	// which is unavailable here (CommitCallback fires after MetaTransaction::Commit closes it).
+	table_entry->table.AddPendingBackfill(version, commit_file_name);
+
 	UCAPI::PostCommit(context, table_id, table_location, credentials, version, commit_timestamp, commit_file_name,
-	                  commit_file_size, file_modification_timestamp);
+	                  commit_file_size, file_modification_timestamp, table_entry->table.backfilled_through);
 
 	// Mark dirty after a successful commit so the next read re-attaches with a fresh log tail
 	table_entry->table.MarkDirty();

--- a/src/include/storage/uc_table_set.hpp
+++ b/src/include/storage/uc_table_set.hpp
@@ -32,12 +32,14 @@ public:
 	void MarkDirty();
 	void AddPendingBackfill(idx_t version, const string &staged_file_name);
 	// Copies any queued staged commits to _delta_log/ and advances backfilled_through.
-	// Must be called with S3 credentials already registered (call RefreshCredentials first).
-	// Called from InternalAttach; kept separate so the locking story is clear.
-	void FlushPendingBackfills(ClientContext &context);
+	// Caller must hold attach_lock (pass the guard as proof); call RefreshCredentials first.
+	void FlushPendingBackfills(ClientContext &context, const lock_guard<mutex> &_attach_lock);
 
 private:
 	string AttachedCatalogName() const;
+	// Shared copy loop used by FlushPendingBackfills and the GetCommits path in InternalAttach.
+	// Caller must hold attach_lock.
+	void BackfillCommitList(ClientContext &context, const vector<UCAPICommit> &commits);
 	bool is_dirty = false;
 
 public:

--- a/src/include/storage/uc_table_set.hpp
+++ b/src/include/storage/uc_table_set.hpp
@@ -30,6 +30,11 @@ public:
 	void InternalCheckpoint(ClientContext &context, bool force);
 	bool IsCCV2() const;
 	void MarkDirty();
+	void AddPendingBackfill(idx_t version, const string &staged_file_name);
+	// Copies any queued staged commits to _delta_log/ and advances backfilled_through.
+	// Must be called with S3 credentials already registered (call RefreshCredentials first).
+	// Called from InternalAttach; kept separate so the locking story is clear.
+	void FlushPendingBackfills(ClientContext &context);
 
 private:
 	string AttachedCatalogName() const;
@@ -41,6 +46,15 @@ public:
 	unique_ptr<UCAPITable> table_data;
 	shared_ptr<AttachedDatabase> internal_attached_database;
 	optional_ptr<Transaction> active_transaction;
+
+	// Delta CMT backfill: after a successful commit, the staged file in _staged_commits/ must be
+	// copied to _delta_log/ and UC notified (via latest_backfilled_version in PostCommit). The copy
+	// can't happen inside CommitCallback because SecretManager needs an active catalog transaction
+	// (even for reads). Instead, each commit queues itself in backfills_pending; the queue is drained
+	// on the next InternalAttach, which always has a valid transaction and fresh S3 credentials.
+	// backfilled_through is a watermark: versions <= it are skipped to avoid redundant S3 round-trips.
+	vector<UCAPICommit> backfills_pending; // staged commits waiting to be copied to _delta_log/
+	int64_t backfilled_through = -1;       // highest version successfully copied
 
 	//! Guards schema_versions and dummy
 	mutex entry_lock;

--- a/src/include/uc_api.hpp
+++ b/src/include/uc_api.hpp
@@ -76,8 +76,7 @@ public:
 	                                     const UCCredentials &credentials);
 	static bool PostCommit(ClientContext &ctx, const string &table_id, const string &table_uri,
 	                       const UCCredentials &credentials, idx_t version, idx_t timestamp, const string &file_name,
-	                       idx_t file_size, idx_t file_modification_timestamp,
-	                       int64_t latest_backfilled_version = -1);
+	                       idx_t file_size, idx_t file_modification_timestamp, int64_t latest_backfilled_version = -1);
 };
 
 } // namespace duckdb

--- a/src/include/uc_api.hpp
+++ b/src/include/uc_api.hpp
@@ -76,7 +76,8 @@ public:
 	                                     const UCCredentials &credentials);
 	static bool PostCommit(ClientContext &ctx, const string &table_id, const string &table_uri,
 	                       const UCCredentials &credentials, idx_t version, idx_t timestamp, const string &file_name,
-	                       idx_t file_size, idx_t file_modification_timestamp);
+	                       idx_t file_size, idx_t file_modification_timestamp,
+	                       int64_t latest_backfilled_version = -1);
 };
 
 } // namespace duckdb

--- a/src/storage/uc_table_set.cpp
+++ b/src/storage/uc_table_set.cpp
@@ -57,8 +57,9 @@ optional_ptr<CatalogEntry> TableInformation::GetVersion(ClientContext &context, 
 	}
 
 	// Not cached: attach and fetch schema — done outside entry_lock since it may block on I/O
-	InternalAttach(context);
+	// RefreshCredentials first: InternalAttach may flush pending backfills, thus needing the credentials.
 	RefreshCredentials(context);
+	InternalAttach(context);
 	auto &delta_catalog = *GetInternalCatalog();
 	auto &schema = delta_catalog.GetSchema(context, table_data->schema_name);
 	auto transaction = schema.GetCatalogTransaction(context);
@@ -125,6 +126,49 @@ void TableInformation::InternalDetach(ClientContext &context, const lock_guard<m
 	internal_attached_database = nullptr;
 }
 
+static void CopyStagedCommitToDeltaLog(ClientContext &context, const string &staged_path,
+                                       const string &storage_location, idx_t version) {
+	auto &fs = FileSystem::GetFileSystem(context);
+	string dst = StringUtil::Format("%s/_delta_log/%020llu.json", storage_location, version);
+	constexpr idx_t BUFFER_SIZE = 64ULL * 1024 * 1024;
+	auto buf = make_unsafe_uniq_array<char>(BUFFER_SIZE);
+	auto src_file = fs.OpenFile(staged_path, FileOpenFlags::FILE_FLAGS_READ);
+	auto dst_file = fs.OpenFile(dst, FileOpenFlags::FILE_FLAGS_WRITE | FileOpenFlags::FILE_FLAGS_FILE_CREATE_NEW);
+	int64_t n;
+	while ((n = src_file->Read(buf.get(), BUFFER_SIZE)) > 0) {
+		dst_file->Write(buf.get(), n);
+	}
+	dst_file->Close();
+}
+
+void TableInformation::AddPendingBackfill(idx_t version, const string &staged_file_name) {
+	lock_guard<mutex> l(attach_lock);
+	UCAPICommit entry;
+	entry.version = (int64_t)version;
+	entry.file_name = staged_file_name;
+	backfills_pending.push_back(std::move(entry));
+}
+
+void TableInformation::FlushPendingBackfills(ClientContext &context) {
+	// Dequeue all pending entries atomically; they are not retried on the next attach — the
+	// GetCommits loop below is the fallback for anything that fails here.
+	auto to_flush = std::move(backfills_pending);
+	for (auto &bf : to_flush) {
+		if (bf.version <= backfilled_through) {
+			continue;
+		}
+		string staged_path = table_data->storage_location + "/_delta_log/_staged_commits/" + bf.file_name;
+		try {
+			CopyStagedCommitToDeltaLog(context, staged_path, table_data->storage_location, (idx_t)bf.version);
+			backfilled_through = bf.version;
+		} catch (...) {
+			// Stop on first failure: continuing would advance backfilled_through past a gap,
+			// causing UC to believe commits it hasn't seen are durably backfilled.
+			break;
+		}
+	}
+}
+
 void TableInformation::MarkDirty() {
 	lock_guard<mutex> l(attach_lock);
 	is_dirty = true;
@@ -169,6 +213,9 @@ void TableInformation::InternalAttach(ClientContext &context) {
 		InternalDetach(context, l);
 		is_dirty = false;
 	}
+
+	FlushPendingBackfills(context);
+
 	if (internal_attached_database) {
 		return;
 	}
@@ -192,6 +239,20 @@ void TableInformation::InternalAttach(ClientContext &context) {
 		info.options["parent_catalog_schema"] = Value(schema.name);
 		info.options["parent_commit"] = Value(true);
 		info.options["max_catalog_version"] = Value::BIGINT(commits.latest_table_version);
+		for (auto &commit : commits.commits) {
+			if (commit.version <= backfilled_through) {
+				continue;
+			}
+			string staged_path = table_data->storage_location + "/_delta_log/_staged_commits/" + commit.file_name;
+			try {
+				CopyStagedCommitToDeltaLog(context, staged_path, table_data->storage_location, (idx_t)commit.version);
+				backfilled_through = commit.version;
+			} catch (...) {
+				// Stop on first failure — same reason as FlushPendingBackfills: gaps would corrupt
+				// backfilled_through and mislead UC about durability.
+				break;
+			}
+		}
 		if (!commits.commits.empty()) {
 			info.options["log_tail"] = BuildLogTailFromCommits(commits, table_data->storage_location);
 		}

--- a/src/storage/uc_table_set.cpp
+++ b/src/storage/uc_table_set.cpp
@@ -126,19 +126,24 @@ void TableInformation::InternalDetach(ClientContext &context, const lock_guard<m
 	internal_attached_database = nullptr;
 }
 
-static void CopyStagedCommitToDeltaLog(ClientContext &context, const string &staged_path,
-                                       const string &storage_location, idx_t version) {
+// Returns false if dst already exists (another session backfilled it); throws on real errors.
+static bool CopyStagedCommitToDeltaLog(ClientContext &context, const string &src, const string &dst) {
+	constexpr idx_t BUFFER_SIZE = 8ULL * 1024 * 1024;
 	auto &fs = FileSystem::GetFileSystem(context);
-	string dst = StringUtil::Format("%s/_delta_log/%020llu.json", storage_location, version);
-	constexpr idx_t BUFFER_SIZE = 64ULL * 1024 * 1024;
-	auto buf = make_unsafe_uniq_array<char>(BUFFER_SIZE);
-	auto src_file = fs.OpenFile(staged_path, FileOpenFlags::FILE_FLAGS_READ);
-	auto dst_file = fs.OpenFile(dst, FileOpenFlags::FILE_FLAGS_WRITE | FileOpenFlags::FILE_FLAGS_FILE_CREATE_NEW);
-	int64_t n;
-	while ((n = src_file->Read(buf.get(), BUFFER_SIZE)) > 0) {
-		dst_file->Write(buf.get(), n);
+	auto src_file = fs.OpenFile(src, FileOpenFlags::FILE_FLAGS_READ);
+	auto dst_file = fs.OpenFile(dst, FileOpenFlags::FILE_FLAGS_WRITE | FileOpenFlags::FILE_FLAGS_FILE_CREATE_NEW |
+	                                     FileOpenFlags::FILE_FLAGS_NULL_IF_EXISTS);
+	if (dst_file) {
+		auto buf = make_unsafe_uniq_array<char>(BUFFER_SIZE);
+		int64_t n;
+		while ((n = src_file->Read(buf.get(), BUFFER_SIZE)) > 0) {
+			dst_file->Write(buf.get(), n);
+		}
+		dst_file->Close();
+		return true;
+	} else {
+		return false;
 	}
-	dst_file->Close();
 }
 
 void TableInformation::AddPendingBackfill(idx_t version, const string &staged_file_name) {
@@ -149,24 +154,32 @@ void TableInformation::AddPendingBackfill(idx_t version, const string &staged_fi
 	backfills_pending.push_back(std::move(entry));
 }
 
-void TableInformation::FlushPendingBackfills(ClientContext &context) {
-	// Dequeue all pending entries atomically; they are not retried on the next attach — the
-	// GetCommits loop below is the fallback for anything that fails here.
-	auto to_flush = std::move(backfills_pending);
-	for (auto &bf : to_flush) {
-		if (bf.version <= backfilled_through) {
+void TableInformation::BackfillCommitList(ClientContext &context, const vector<UCAPICommit> &commits) {
+	for (auto &commit : commits) {
+		if (commit.version <= backfilled_through) {
 			continue;
 		}
-		string staged_path = table_data->storage_location + "/_delta_log/_staged_commits/" + bf.file_name;
+		string src = table_data->storage_location + "/_delta_log/_staged_commits/" + commit.file_name;
+		string dst =
+		    StringUtil::Format("%s/_delta_log/%020llu.json", table_data->storage_location, (uint64_t)commit.version);
 		try {
-			CopyStagedCommitToDeltaLog(context, staged_path, table_data->storage_location, (idx_t)bf.version);
-			backfilled_through = bf.version;
+			// TODO: consider? prefetch _delta_log/ listing (name + size) and skip copies where both match,
+			//       eliminating file/object open round trips if the list is >1 length.
+			if (!CopyStagedCommitToDeltaLog(context, src, dst)) {
+				// false = dst already exists; another session beat us — still update backfill version
+			}
+			backfilled_through = commit.version;
 		} catch (...) {
-			// Stop on first failure: continuing would advance backfilled_through past a gap,
-			// causing UC to believe commits it hasn't seen are durably backfilled.
+			// Real failure — stop to avoid advancing backfilled_through past a gap.
 			break;
 		}
 	}
+}
+
+void TableInformation::FlushPendingBackfills(ClientContext &context, const lock_guard<mutex> &) {
+	// Dequeue atomically; not retried — GetCommits path in InternalAttach is the fallback.
+	auto to_flush = std::move(backfills_pending);
+	BackfillCommitList(context, to_flush);
 }
 
 void TableInformation::MarkDirty() {
@@ -214,7 +227,7 @@ void TableInformation::InternalAttach(ClientContext &context) {
 		is_dirty = false;
 	}
 
-	FlushPendingBackfills(context);
+	FlushPendingBackfills(context, l);
 
 	if (internal_attached_database) {
 		return;
@@ -239,20 +252,7 @@ void TableInformation::InternalAttach(ClientContext &context) {
 		info.options["parent_catalog_schema"] = Value(schema.name);
 		info.options["parent_commit"] = Value(true);
 		info.options["max_catalog_version"] = Value::BIGINT(commits.latest_table_version);
-		for (auto &commit : commits.commits) {
-			if (commit.version <= backfilled_through) {
-				continue;
-			}
-			string staged_path = table_data->storage_location + "/_delta_log/_staged_commits/" + commit.file_name;
-			try {
-				CopyStagedCommitToDeltaLog(context, staged_path, table_data->storage_location, (idx_t)commit.version);
-				backfilled_through = commit.version;
-			} catch (...) {
-				// Stop on first failure — same reason as FlushPendingBackfills: gaps would corrupt
-				// backfilled_through and mislead UC about durability.
-				break;
-			}
-		}
+		BackfillCommitList(context, commits.commits);
 		if (!commits.commits.empty()) {
 			info.options["log_tail"] = BuildLogTailFromCommits(commits, table_data->storage_location);
 		}

--- a/src/storage/unity_catalog.cpp
+++ b/src/storage/unity_catalog.cpp
@@ -106,8 +106,9 @@ PhysicalOperator &UnityCatalog::PlanInsert(ClientContext &context, PhysicalPlanG
 	auto &table_entry = op.table.Cast<UCTableEntry>();
 	auto &table = table_entry.table;
 
-	table.InternalAttach(context);
+	// Credentials before Attach, since attach may backfill and need them.
 	table.RefreshCredentials(context);
+	table.InternalAttach(context);
 
 	auto internal_catalog = table.GetInternalCatalog();
 	return internal_catalog->PlanInsert(context, planner, op, plan);

--- a/src/uc_api.cpp
+++ b/src/uc_api.cpp
@@ -243,10 +243,14 @@ UCAPICommitsResult UCAPI::GetCommits(ClientContext &ctx, const string &table_id,
 
 bool UCAPI::PostCommit(ClientContext &ctx, const string &table_id, const string &table_uri,
                        const UCCredentials &credentials, idx_t version, idx_t timestamp, const string &file_name,
-                       idx_t file_size, idx_t file_modification_timestamp) {
+                       idx_t file_size, idx_t file_modification_timestamp, int64_t latest_backfilled_version) {
+	string backfill_field;
+	if (latest_backfilled_version >= 0) {
+		backfill_field = StringUtil::Format(R"("latest_backfilled_version": %lld,)", latest_backfilled_version);
+	}
 	string body = StringUtil::Format(
-	    R"({"table_id": "%s", "table_uri": "%s/", "commit_info": {"version": %ld, "timestamp": %ld, "file_name": "%s", "file_size": %ld, "file_modification_timestamp": %ld}})",
-	    table_id.c_str(), table_uri.c_str(), version, timestamp, file_name.c_str(), file_size,
+	    R"({"table_id": "%s", "table_uri": "%s/", %s "commit_info": {"version": %ld, "timestamp": %ld, "file_name": "%s", "file_size": %ld, "file_modification_timestamp": %ld}})",
+	    table_id.c_str(), table_uri.c_str(), backfill_field.c_str(), version, timestamp, file_name.c_str(), file_size,
 	    file_modification_timestamp);
 	string url = credentials.endpoint + "/api/2.1/unity-catalog/delta/preview/commits";
 	auto api_result = MakeRequest(ctx, url, credentials.token, body);

--- a/test/sql/databricks/write_tests/write_catalog_managed.test
+++ b/test/sql/databricks/write_tests/write_catalog_managed.test
@@ -79,3 +79,35 @@ SELECT parse_filename(file)[0:21] AS f FROM GLOB(getvariable('table_path') || '/
 ----
 00000000000000000001.
 00000000000000000002.
+
+# -----------------------------------------------------------------------------
+# Backfill verification — 3 iterations is enough to confirm the pattern repeats.
+# Confidence: SELECT count(*) = 10 proves the Delta kernel can read all committed
+# data, which requires backfill to have happened. The staged commits list at the
+# end explicitly ties the file-scan result to the 2 initial inserts above + 3 loop
+# inserts (v1-v5 total).
+#
+
+loop i 0 3
+
+statement ok
+INSERT INTO simple_table_catalog_managed VALUES (1000 + {i});
+
+endloop
+
+# Flush the last loop iteration's pending backfill; all 10 rows readable proves
+# backfill succeeded for all 5 DuckDB commits (Delta kernel reads from _delta_log/).
+query I
+SELECT count(*) FROM simple_table_catalog_managed;
+----
+10
+
+# All 5 staged commits present (v1-v2 from initial inserts above, v3-v5 from loop).
+query I
+SELECT parse_filename(file)[0:21] AS f FROM GLOB(getvariable('table_path') || '/_delta_log/_staged_commits/**/*') ORDER BY f;
+----
+00000000000000000001.
+00000000000000000002.
+00000000000000000003.
+00000000000000000004.
+00000000000000000005.

--- a/test/sql/local_oss_unity_catalog/uc_catalog_write.test
+++ b/test/sql/local_oss_unity_catalog/uc_catalog_write.test
@@ -37,3 +37,14 @@ FROM marksheet;
 
 statement ok
 INSERT INTO marksheet VALUES(1, 'blabla', 1337);
+
+# Second insert verifies PlanInsert credential ordering (RefreshCredentials before InternalAttach).
+# marksheet is not catalog-managed (no delta.feature.catalogManaged property), so no backfill applies here.
+statement ok
+INSERT INTO marksheet VALUES(2, 'blabla2', 1338);
+
+query III
+SELECT id, name, marks FROM marksheet WHERE id IN (1, 2) ORDER BY id;
+----
+1	blabla	1337
+2	blabla2	1338


### PR DESCRIPTION
Backfilling now fully implemented, with one caveat.

Backfills now occur at attach time; all outstanding ratified commits will be backfilled, and signalled as moved. When a commit occurs, its ratified commit will remain in the backfill list, to be moved and signalled at the _next_ attach. (The caveat.)

This deferred strategy is required with current DuckDB due to lack of credentials post commit. Addressing this cleanly likely requires some changes to DuckDB's credential handling. Further the entire backfill process would happen in the background; these remain future work.