### PR TITLE
setup to deploy (additionally) to version=protocol_preview

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -39,20 +39,6 @@ jobs:
       deploy_versioned: ${{ startsWith(github.ref, 'refs/heads/v') || github.ref == 'refs/heads/main' }}
       reduced_ci_mode: ${{ github.event_name == 'pull_request' && 'enabled' || 'disabled'}}
 
-  duckdb-stable-protocol-preview-deploy:
-    name: Deploy extension binaries (version=protocol_preview)
-    needs: duckdb-stable-build
-    uses: duckdb/extension-ci-tools/.github/workflows/_extension_deploy.yml@v1.5-variegata
-    secrets: inherit
-    with:
-      extension_name: *ext_name
-      extension_explicit_version: protocol_preview
-      duckdb_version: *duckdb_ref
-      ci_tools_version: *ci_tools_ref
-      exclude_archs: wasm_mvp;wasm_eh;wasm_threads;windows_amd64_mingw;windows_amd64;linux_arm64;linux_amd64_musl
-      deploy_versioned: ${{ startsWith(github.ref, 'refs/heads/v') || github.ref == 'refs/heads/main' }}
-      reduced_ci_mode: ${{ github.event_name == 'pull_request' && 'enabled' || 'disabled'}}
-
   code-quality-check:
     name: Code Quality Check
     uses: duckdb/extension-ci-tools/.github/workflows/_extension_code_quality.yml@v1.5-variegata

--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -17,7 +17,7 @@ jobs:
     uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@v1.5-variegata
     with:
       extension_name: &ext_name unity_catalog
-      duckdb_version: &duckdb_ref v1.5.3
+      duckdb_version: &duckdb_ref v1.5.4
       ci_tools_version: &ci_tools_ref v1.5-variegata
       exclude_archs: wasm_mvp;wasm_eh;wasm_threads;windows_amd64_mingw;windows_amd64;linux_arm64;linux_amd64_musl
       enable_rust: true
@@ -36,6 +36,20 @@ jobs:
       ci_tools_version: *ci_tools_ref
       exclude_archs: wasm_mvp;wasm_eh;wasm_threads;windows_amd64_mingw;windows_amd64;linux_arm64;linux_amd64_musl
       deploy_latest: ${{ startsWith(github.ref, 'refs/heads/v') || github.ref == 'refs/heads/main' }}
+      deploy_versioned: ${{ startsWith(github.ref, 'refs/heads/v') || github.ref == 'refs/heads/main' }}
+      reduced_ci_mode: ${{ github.event_name == 'pull_request' && 'enabled' || 'disabled'}}
+
+  duckdb-stable-protocol-preview-deploy:
+    name: Deploy extension binaries (version=protocol_preview)
+    needs: duckdb-stable-build
+    uses: duckdb/extension-ci-tools/.github/workflows/_extension_deploy.yml@v1.5-variegata
+    secrets: inherit
+    with:
+      extension_name: *ext_name
+      extension_explicit_version: protocol_preview
+      duckdb_version: *duckdb_ref
+      ci_tools_version: *ci_tools_ref
+      exclude_archs: wasm_mvp;wasm_eh;wasm_threads;windows_amd64_mingw;windows_amd64;linux_arm64;linux_amd64_musl
       deploy_versioned: ${{ startsWith(github.ref, 'refs/heads/v') || github.ref == 'refs/heads/main' }}
       reduced_ci_mode: ${{ github.event_name == 'pull_request' && 'enabled' || 'disabled'}}
 


### PR DESCRIPTION
Bumps to v1.5.4 for a manual push to protocol_preview. There might be a follow up to (semi)automate the pushes, TBD.