### PR TITLE
backport file flag fix on backfill process

### DIFF
--- a/src/include/uc_logging.hpp
+++ b/src/include/uc_logging.hpp
@@ -1,0 +1,9 @@
+#pragma once
+
+#include "duckdb/logging/logger.hpp"
+
+// Extension-scoped logging macros. Log type "unity_catalog" lets users filter
+// UC extension messages independently of other DuckDB subsystems.
+#define UC_LOG_DEBUG(SOURCE, ...)   DUCKDB_LOG_INTERNAL(SOURCE, "unity_catalog", LogLevel::LOG_DEBUG, __VA_ARGS__)
+#define UC_LOG_WARNING(SOURCE, ...) DUCKDB_LOG_INTERNAL(SOURCE, "unity_catalog", LogLevel::LOG_WARNING, __VA_ARGS__)
+#define UC_LOG_ERROR(SOURCE, ...)   DUCKDB_LOG_INTERNAL(SOURCE, "unity_catalog", LogLevel::LOG_ERROR, __VA_ARGS__)

--- a/src/storage/uc_table_set.cpp
+++ b/src/storage/uc_table_set.cpp
@@ -1,4 +1,5 @@
 #include "uc_api.hpp"
+#include "uc_logging.hpp"
 #include "uc_utils.hpp"
 
 #include "storage/unity_catalog.hpp"
@@ -131,8 +132,12 @@ static bool CopyStagedCommitToDeltaLog(ClientContext &context, const string &src
 	constexpr idx_t BUFFER_SIZE = 8ULL * 1024 * 1024;
 	auto &fs = FileSystem::GetFileSystem(context);
 	auto src_file = fs.OpenFile(src, FileOpenFlags::FILE_FLAGS_READ);
-	auto dst_file = fs.OpenFile(dst, FileOpenFlags::FILE_FLAGS_WRITE | FileOpenFlags::FILE_FLAGS_FILE_CREATE_NEW |
-	                                     FileOpenFlags::FILE_FLAGS_NULL_IF_EXISTS);
+	// Exclusive create + null-if-exists: skip (return null) if another session already backfilled
+	// this version, rather than clobbering it. NULL_IF_EXISTS is only valid with EXCLUSIVE_CREATE
+	// (asserted in debug builds); EXCLUSIVE_CREATE in turn requires a base FILE_CREATE.
+	auto dst_flags = FileOpenFlags::FILE_FLAGS_WRITE | FileOpenFlags::FILE_FLAGS_FILE_CREATE |
+	                 FileOpenFlags::FILE_FLAGS_EXCLUSIVE_CREATE | FileOpenFlags::FILE_FLAGS_NULL_IF_EXISTS;
+	auto dst_file = fs.OpenFile(dst, dst_flags);
 	if (dst_file) {
 		auto buf = make_unsafe_uniq_array<char>(BUFFER_SIZE);
 		int64_t n;
@@ -169,8 +174,12 @@ void TableInformation::BackfillCommitList(ClientContext &context, const vector<U
 				// false = dst already exists; another session beat us — still update backfill version
 			}
 			backfilled_through = commit.version;
-		} catch (...) {
-			// Real failure — stop to avoid advancing backfilled_through past a gap.
+		} catch (std::exception &e) {
+			// Real failure — stop to avoid advancing backfilled_through past a gap. Surface it: a
+			// silently-swallowed backfill failure lets staged commits accumulate until the server
+			// rejects further commits (HTTP 429, "too many un-backfilled commits").
+			UC_LOG_WARNING(context, "uc.BackfillCommitList version=%lld src=%s dst=%s failed: %s",
+			               (long long)commit.version, src.c_str(), dst.c_str(), e.what());
 			break;
 		}
 	}

--- a/src/uc_api.cpp
+++ b/src/uc_api.cpp
@@ -7,6 +7,7 @@
 #include "duckdb/main/extension_helper.hpp"
 
 #include "uc_api.hpp"
+#include "uc_logging.hpp"
 #include "storage/unity_catalog.hpp"
 #include "yyjson.hpp"
 
@@ -187,6 +188,7 @@ static string GetCredentialsRequest(ClientContext &ctx, const string &url, const
 //  	--header "Authorization: Bearer ${TOKEN}" | jq .
 
 string UCAPI::GetDefaultSchema(ClientContext &ctx, const UCCredentials &credentials) {
+	UC_LOG_DEBUG(ctx, "uc-api.GetDefaultSchema endpoint=%s", credentials.endpoint);
 	auto url = credentials.endpoint + "/api/2.0/settings/types/default_namespace_ws/names/default";
 	auto resp = MakeRequest(ctx, url, credentials.token);
 
@@ -210,6 +212,7 @@ string UCAPI::GetDefaultSchema(ClientContext &ctx, const UCCredentials &credenti
 UCAPICommitsResult UCAPI::GetCommits(ClientContext &ctx, const string &table_id, const string &table_uri,
                                      const UCCredentials &credentials) {
 	UCAPICommitsResult result;
+	UC_LOG_DEBUG(ctx, "uc-api.GetCommits table_id=%s", table_id);
 	string body = StringUtil::Format("{\"start_version\": 0, \"table_id\": \"%s\", \"table_uri\": \"%s\"}",
 	                                 table_id.c_str(), table_uri.c_str());
 	string url = credentials.endpoint + "/api/2.1/unity-catalog/delta/preview/commits";
@@ -238,6 +241,8 @@ UCAPICommitsResult UCAPI::GetCommits(ClientContext &ctx, const string &table_id,
 		result.commits.push_back(commit_result);
 	}
 
+	UC_LOG_DEBUG(ctx, "uc-api.GetCommits table_id=%s -> commits=%zu latest_version=%lld", table_id,
+	             result.commits.size(), (long long)result.latest_table_version);
 	return result;
 }
 
@@ -245,9 +250,13 @@ bool UCAPI::PostCommit(ClientContext &ctx, const string &table_id, const string 
                        const UCCredentials &credentials, idx_t version, idx_t timestamp, const string &file_name,
                        idx_t file_size, idx_t file_modification_timestamp, int64_t latest_backfilled_version) {
 	string backfill_field;
+	string backfill_log("(none)");
 	if (latest_backfilled_version >= 0) {
 		backfill_field = StringUtil::Format(R"("latest_backfilled_version": %lld,)", latest_backfilled_version);
+		backfill_log = to_string((int64_t)latest_backfilled_version);
 	}
+	UC_LOG_DEBUG(ctx, "uc-api.PostCommit table_id=%s version=%lld backfill_version=%s", table_id, (long long)version,
+	             backfill_log);
 	string body = StringUtil::Format(
 	    R"({"table_id": "%s", "table_uri": "%s/", %s "commit_info": {"version": %ld, "timestamp": %ld, "file_name": "%s", "file_size": %ld, "file_modification_timestamp": %ld}})",
 	    table_id.c_str(), table_uri.c_str(), backfill_field.c_str(), version, timestamp, file_name.c_str(), file_size,
@@ -263,12 +272,14 @@ bool UCAPI::PostCommit(ClientContext &ctx, const string &table_id, const string 
 		error.ThrowError(StringUtil::Format("Failed to commit to %s", table_id));
 	}
 
+	UC_LOG_DEBUG(ctx, "uc-api.PostCommit table_id=%s version=%lld -> ok", table_id, (long long)version);
 	return true;
 }
 
 UCAPITableCredentials UCAPI::GetTableCredentials(ClientContext &ctx, const string &table_id, bool write,
                                                  const UCCredentials &credentials) {
 	UCAPITableCredentials result;
+	UC_LOG_DEBUG(ctx, "uc-api.GetTableCredentials table_id=%s op=%s", table_id, write ? "READ_WRITE" : "READ");
 
 	auto url = credentials.endpoint + "/api/2.1/unity-catalog/temporary-table-credentials";
 	auto api_result = GetCredentialsRequest(ctx, url, table_id, write, credentials.token);
@@ -310,6 +321,7 @@ static UCAPIColumnDefinition ParseColumnDefinition(duckdb_yyjson::yyjson_val *co
 vector<UCAPITable> UCAPI::GetTables(ClientContext &ctx, Catalog &catalog, const string &schema,
                                     const UCCredentials &credentials) {
 	vector<UCAPITable> result;
+	UC_LOG_DEBUG(ctx, "uc-api.GetTables catalog=%s schema=%s", catalog.GetDBPath(), schema);
 	auto url = credentials.endpoint + "/api/2.1/unity-catalog/tables?catalog_name=" + catalog.GetDBPath() +
 	           "&schema_name=" + schema;
 	auto api_result = MakeRequest(ctx, url, credentials.token);
@@ -353,11 +365,14 @@ vector<UCAPITable> UCAPI::GetTables(ClientContext &ctx, Catalog &catalog, const 
 		result.push_back(table_result);
 	}
 
+	UC_LOG_DEBUG(ctx, "uc-api.GetTables catalog=%s schema=%s -> tables=%zu", catalog.GetDBPath(), schema,
+	             result.size());
 	return result;
 }
 
 vector<UCAPISchema> UCAPI::GetSchemas(ClientContext &ctx, Catalog &catalog, const UCCredentials &credentials) {
 	vector<UCAPISchema> result;
+	UC_LOG_DEBUG(ctx, "uc-api.GetSchemas catalog=%s", catalog.GetDBPath());
 	auto url = credentials.endpoint + "/api/2.1/unity-catalog/schemas?catalog_name=" + catalog.GetDBPath();
 	auto api_result = MakeRequest(ctx, url, credentials.token);
 
@@ -380,6 +395,7 @@ vector<UCAPISchema> UCAPI::GetSchemas(ClientContext &ctx, Catalog &catalog, cons
 		result.push_back(schema_result);
 	}
 
+	UC_LOG_DEBUG(ctx, "uc-api.GetSchemas catalog=%s -> schemas=%zu", catalog.GetDBPath(), result.size());
 	return result;
 }
 

--- a/test/sql/local_oss_unity_catalog/checkpoint.test
+++ b/test/sql/local_oss_unity_catalog/checkpoint.test
@@ -25,9 +25,10 @@ CREATE SECRET (
 statement ok
 ATTACH 'unity' AS my_catalog (TYPE UNITY_CATALOG, DEFAULT_SCHEMA 'default');
 
-# query to trigger attach
+# query to trigger attach;
+# backport NOTE: < 1000 avoids writer pollution, fixed in v1.5-variegata
 query III
-FROM my_catalog.default.marksheet;
+FROM my_catalog.default.marksheet WHERE id < 1000;
 ----
 1	nWYHawtqUw	930
 2	uvOzzthsLV	166
@@ -88,11 +89,10 @@ statement ok
 USE my_catalog.default; CALL unity_catalog_checkpoint_table('user_countries');
 
 # Confirm all checkpoints via presence of checkpoint files
+# backport NOTE: skip marksheet because of writer pollution, fixed in v1.5-variegata
 query II rowsort
-SELECT parse_path(file)[-3], parse_path(file)[-1] FROM glob('${UC_TEST_DATA}/**/*checkpoint*');
+SELECT parse_path(file)[-3], parse_path(file)[-1] FROM glob('${UC_TEST_DATA}/**/*checkpoint*') WHERE file NOT LIKE '%/marksheet/%';
 ----
-marksheet	00000000000000000001.checkpoint.parquet
-marksheet	_last_checkpoint
 marksheet_uniform	00000000000000000001.checkpoint.parquet
 marksheet_uniform	_last_checkpoint
 numbers	00000000000000000000.checkpoint.parquet

--- a/test/sql/local_oss_unity_catalog/http_logs.test
+++ b/test/sql/local_oss_unity_catalog/http_logs.test
@@ -28,8 +28,9 @@ statement ok
 ATTACH 'unity' AS my_catalog (TYPE unity_catalog);
 
 # We can now query the tables in the schema!
+# backport NOTE: < 1000 avoids writer pollution, fixed in v1.5-variegata
 query I
-SELECT count(*) FROM my_catalog.default.marksheet;
+SELECT count(*) FROM my_catalog.default.marksheet WHERE id < 1000;
 ----
 15
 

--- a/test/sql/local_oss_unity_catalog/uc_catalog_write.test
+++ b/test/sql/local_oss_unity_catalog/uc_catalog_write.test
@@ -5,11 +5,11 @@
 # Require statement will ensure this test is run with this extension loaded
 require parquet
 
-require uc_catalog
+require httpfs
 
 require delta
 
-require httpfs
+require unity_catalog
 
 require-env UC_TEST_SERVER_RUNNING
 
@@ -36,15 +36,15 @@ statement ok
 FROM marksheet;
 
 statement ok
-INSERT INTO marksheet VALUES(1, 'blabla', 1337);
+INSERT INTO marksheet VALUES(1001, 'blabla', 1337);
 
 # Second insert verifies PlanInsert credential ordering (RefreshCredentials before InternalAttach).
 # marksheet is not catalog-managed (no delta.feature.catalogManaged property), so no backfill applies here.
 statement ok
-INSERT INTO marksheet VALUES(2, 'blabla2', 1338);
+INSERT INTO marksheet VALUES(1002, 'blabla2', 1338);
 
 query III
-SELECT id, name, marks FROM marksheet WHERE id IN (1, 2) ORDER BY id;
+SELECT id, name, marks FROM marksheet WHERE id IN (1001, 1002) ORDER BY id;
 ----
-1	blabla	1337
-2	blabla2	1338
+1001	blabla	1337
+1002	blabla2	1338

--- a/test/sql/local_oss_unity_catalog/uc_catalog_write.test
+++ b/test/sql/local_oss_unity_catalog/uc_catalog_write.test
@@ -43,8 +43,11 @@ INSERT INTO marksheet VALUES(1001, 'blabla', 1337);
 statement ok
 INSERT INTO marksheet VALUES(1002, 'blabla2', 1338);
 
+# backport NOTE: DISTINCT keeps this idempotent on a persistent local server — re-runs
+# re-INSERT 1001/1002, and DISTINCT collapses the duplicates back to two rows. HEAD writes to
+# a dedicated _rw table instead.
 query III
-SELECT id, name, marks FROM marksheet WHERE id IN (1001, 1002) ORDER BY id;
+SELECT DISTINCT id, name, marks FROM marksheet WHERE id IN (1001, 1002) ORDER BY id;
 ----
 1001	blabla	1337
 1002	blabla2	1338

--- a/test/sql/local_oss_unity_catalog/unity_catalog.test
+++ b/test/sql/local_oss_unity_catalog/unity_catalog.test
@@ -36,8 +36,9 @@ statement ok
 USE my_catalog.default;
 
 # We can now query the tables in the schema!
+# backport NOTE: < 1000 avoids writer pollution, fixed in v1.5-variegata
 query III
-FROM marksheet;
+FROM marksheet WHERE id < 1000;
 ----
 1	nWYHawtqUw	930
 2	uvOzzthsLV	166
@@ -85,8 +86,9 @@ my_catalog	default	user_countries
 #mode output_result
 
 # Use the default schema
+# backport NOTE: < 1000 avoids writer pollution, fixed in v1.5-variegata
 query III
-FROM marksheet;
+FROM marksheet WHERE id < 1000;
 ----
 1	nWYHawtqUw	930
 2	uvOzzthsLV	166


### PR DESCRIPTION
Also backport uc-api logging, and hand-tweak tests to avoid read-write pollution (which is structurally fixed in head)