### PR TITLE
Test the catalog write path, bump duckdb main

### DIFF
--- a/data/char_varchar_c1/_delta_log/00000000000000000000.json
+++ b/data/char_varchar_c1/_delta_log/00000000000000000000.json
@@ -1,0 +1,3 @@
+{"commitInfo": {"timestamp": 1700000000000, "operation": "CREATE TABLE", "operationParameters": {}, "isolationLevel": "Serializable", "isBlindAppend": true}}
+{"metaData": {"id": "00000000-0000-0000-0000-0000000000c1", "format": {"provider": "parquet", "options": {}}, "schemaString": "{\"type\": \"struct\", \"fields\": [{\"name\": \"id\", \"type\": \"integer\", \"nullable\": true, \"metadata\": {}}, {\"name\": \"code\", \"type\": \"string\", \"nullable\": true, \"metadata\": {\"__CHAR_VARCHAR_TYPE_STRING\": \"char(5)\"}}]}", "partitionColumns": [], "configuration": {}, "createdTime": 1700000000000}}
+{"protocol": {"minReaderVersion": 1, "minWriterVersion": 2}}

--- a/extension_config.cmake
+++ b/extension_config.cmake
@@ -9,6 +9,6 @@ duckdb_extension_load(unity_catalog
 # NOTE: replace with SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/../delta for local dev
 duckdb_extension_load(delta
     GIT_URL https://github.com/duckdb/duckdb-delta
-    GIT_TAG ccd80e5b9c3a7263da1c0b0c810d404563300a41
+    GIT_TAG d42993d5684946bcb7efacb7a4102021687623f7
     SUBMODULES extension-ci-tools
 )

--- a/extension_config.cmake
+++ b/extension_config.cmake
@@ -9,6 +9,6 @@ duckdb_extension_load(unity_catalog
 # NOTE: replace with SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/../delta for local dev
 duckdb_extension_load(delta
     GIT_URL https://github.com/duckdb/duckdb-delta
-    GIT_TAG 755898cd8469c1d2bcb69989e7c80c024dc031cd
+    GIT_TAG ccd80e5b9c3a7263da1c0b0c810d404563300a41
     SUBMODULES extension-ci-tools
 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ package = false
 
 # The driver isn't published yet — resolve it from the GitHub branch (was: ../driver sibling checkout).
 [tool.uv.sources]
-duckdb-pytest-driver = { git = "https://github.com/benfleis/duckdb-pytest-driver", branch = "dev/v0.2" }
+duckdb-pytest-driver = { git = "https://github.com/benfleis/duckdb-pytest-driver", branch = "dev/v0.3" }
 
 # Conform to duckdb's python black settings
 [tool.ruff]

--- a/src/functions/uc_checkpoint.cpp
+++ b/src/functions/uc_checkpoint.cpp
@@ -50,7 +50,7 @@ static CheckpointTableBindData ResolveTableName(ClientContext &context, const st
 
 template <bool FORCE>
 static unique_ptr<FunctionData> CheckpointTableBind(ClientContext &context, TableFunctionBindInput &input,
-                                                    vector<LogicalType> &return_types, vector<string> &names) {
+                                                    vector<LogicalType> &return_types, vector<Identifier> &names) {
 	auto result = make_uniq<CheckpointTableBindData>(ResolveTableName(context, input.inputs[0].ToString()));
 	result->force = FORCE;
 	return_types.push_back(LogicalType::BOOLEAN);

--- a/src/functions/uc_deletion_vector.cpp
+++ b/src/functions/uc_deletion_vector.cpp
@@ -25,7 +25,7 @@ struct ReadDVGlobalState : public GlobalTableFunctionState {
 };
 
 static unique_ptr<FunctionData> ReadDVBind(ClientContext &, TableFunctionBindInput &input,
-                                           vector<LogicalType> &return_types, vector<string> &names) {
+                                           vector<LogicalType> &return_types, vector<Identifier> &names) {
 	auto result = make_uniq<ReadDVBindData>();
 	result->path = input.inputs[0].ToString();
 

--- a/src/functions/uc_delta_ccv2_commit.cpp
+++ b/src/functions/uc_delta_ccv2_commit.cpp
@@ -16,7 +16,7 @@ unique_ptr<GlobalTableFunctionState> UCDeltaCCV2CommitInit(ClientContext &contex
 }
 
 static unique_ptr<FunctionData> UCDeltaCCV2CommitBind(ClientContext &context, TableFunctionBindInput &input,
-                                                      vector<LogicalType> &return_types, vector<string> &names) {
+                                                      vector<LogicalType> &return_types, vector<Identifier> &names) {
 	throw InternalException(
 	    "__internal_delta_ccv2_commit_staged is only for internal use and should not be called directly");
 }

--- a/src/functions/uc_plan_table_scan.cpp
+++ b/src/functions/uc_plan_table_scan.cpp
@@ -23,7 +23,7 @@ struct PlanScanGlobalState : public GlobalTableFunctionState {
 };
 
 static unique_ptr<FunctionData> PlanScanBind(ClientContext &, TableFunctionBindInput &input,
-                                             vector<LogicalType> &return_types, vector<string> &names) {
+                                             vector<LogicalType> &return_types, vector<Identifier> &names) {
 	auto result = make_uniq<PlanScanBindData>();
 	result->endpoint = input.inputs[0].ToString();
 	result->catalog = input.inputs[1].ToString();

--- a/src/functions/uc_table_data_path.cpp
+++ b/src/functions/uc_table_data_path.cpp
@@ -18,7 +18,7 @@ struct UCTableDataPathBindData : public TableFunctionData {
 };
 
 static unique_ptr<FunctionData> UCTableDataPathBind(ClientContext &context, TableFunctionBindInput &input,
-                                                    vector<LogicalType> &return_types, vector<string> &names) {
+                                                    vector<LogicalType> &return_types, vector<Identifier> &names) {
 	if (!input.info) {
 		throw InternalException("table_data_path: missing function info");
 	}

--- a/src/include/storage/unity_catalog.hpp
+++ b/src/include/storage/unity_catalog.hpp
@@ -39,7 +39,7 @@ public:
 class UnityCatalog : public Catalog {
 public:
 	explicit UnityCatalog(AttachedDatabase &db_p, const string &internal_name, AttachOptions &attach_options,
-	                      UCCredentials credentials, const string &default_schema,
+	                      UCCredentials credentials, const Identifier &default_schema,
 	                      string catalog_name = "unity_catalog");
 	~UnityCatalog() override;
 
@@ -85,7 +85,7 @@ public:
 	                                            unique_ptr<LogicalOperator> plan) override;
 
 	DatabaseSize GetDatabaseSize(ClientContext &context) override;
-	string GetDefaultSchema() const override;
+	Identifier GetDefaultSchema() const override;
 	void OnDetach(ClientContext &context) override;
 
 	//! Whether or not this is an in-memory UC database
@@ -120,7 +120,7 @@ private:
 
 private:
 	UCSchemaSet schemas;
-	string default_schema;
+	Identifier default_schema;
 
 	// Per-ATTACH scan-plan availability, guarded by scan_plan_lock.
 	enum class ScanPlanAvailability : uint8_t { UNKNOWN, AVAILABLE, UNAVAILABLE };

--- a/src/storage/uc_clear_cache.cpp
+++ b/src/storage/uc_clear_cache.cpp
@@ -12,7 +12,7 @@ struct ClearCacheFunctionData : public TableFunctionData {
 };
 
 static unique_ptr<FunctionData> ClearCacheBind(ClientContext &context, TableFunctionBindInput &input,
-                                               vector<LogicalType> &return_types, vector<string> &names) {
+                                               vector<LogicalType> &return_types, vector<Identifier> &names) {
 	auto result = make_uniq<ClearCacheFunctionData>();
 	return_types.push_back(LogicalType::BOOLEAN);
 	names.emplace_back("Success");

--- a/src/storage/uc_table_entry.cpp
+++ b/src/storage/uc_table_entry.cpp
@@ -230,7 +230,7 @@ static unique_ptr<GlobalTableFunctionState> UCScanPlanInitGlobal(ClientContext &
 	vector<Identifier> input_table_names;
 	TableFunctionRef dummy_ref;
 	vector<LogicalType> return_types;
-	vector<string> return_names;
+	vector<Identifier> return_names;
 	TableFunctionBindInput bind_input(inputs, named_params, input_table_types, input_table_names, nullptr, nullptr,
 	                                  parquet_fn, dummy_ref);
 	try {

--- a/src/storage/uc_table_set.cpp
+++ b/src/storage/uc_table_set.cpp
@@ -24,7 +24,7 @@
 namespace duckdb {
 
 static idx_t ParseDeltaVersionFromAtClause(const BoundAtClause &at_clause) {
-	if (StringUtil::Lower(at_clause.Unit()) != "version") {
+	if (at_clause.Unit() != "version") {
 		throw InvalidConfigurationException("Delta tables only support at_clause with unit 'version'");
 	}
 	Value version_value = at_clause.GetValue();

--- a/src/storage/uc_table_set.cpp
+++ b/src/storage/uc_table_set.cpp
@@ -27,12 +27,12 @@ static idx_t ParseDeltaVersionFromAtClause(const BoundAtClause &at_clause) {
 	if (at_clause.Unit() != "version") {
 		throw InvalidConfigurationException("Delta tables only support at_clause with unit 'version'");
 	}
-	Value version_value = at_clause.GetValue();
-	if (!version_value.DefaultTryCastAs(LogicalType::UBIGINT, false)) {
+	auto version_value = at_clause.GetValue().DefaultTryCastAs(LogicalType::UBIGINT);
+	if (!version_value) {
 		throw InvalidInputException("Failed to parse version number '%s' into a valid version",
 		                            at_clause.GetValue().ToString().c_str());
 	}
-	return version_value.GetValue<idx_t>();
+	return version_value->GetValue<idx_t>();
 }
 
 UCTableSet::UCTableSet(UCSchemaEntry &schema) : catalog(schema.ParentCatalog().Cast<UnityCatalog>()), schema(schema) {

--- a/src/storage/unity_catalog.cpp
+++ b/src/storage/unity_catalog.cpp
@@ -15,7 +15,7 @@
 namespace duckdb {
 
 UnityCatalog::UnityCatalog(AttachedDatabase &db_p, const string &internal_name, AttachOptions &attach_options,
-                           UCCredentials credentials, const string &default_schema, string catalog_name_p)
+                           UCCredentials credentials, const Identifier &default_schema, string catalog_name_p)
     : Catalog(db_p), internal_name(internal_name), access_mode(attach_options.access_mode),
       credentials(std::move(credentials)), catalog_name(std::move(catalog_name_p)), schemas(*this),
       default_schema(default_schema) {
@@ -56,7 +56,7 @@ optional_ptr<SchemaCatalogEntry> UnityCatalog::LookupSchema(CatalogTransaction t
 			    "specify a DEFAULT_SCHEMA on ATTACH: `ATTACH '..' (TYPE unity_catalog, DEFAULT_SCHEMA 'my_schema')`",
 			    GetName());
 		}
-		return GetSchema(transaction, Identifier(default_schema), if_not_found);
+		return GetSchema(transaction, default_schema, if_not_found);
 	}
 	auto entry = schemas.GetEntry(transaction.GetContext(), schema_lookup);
 	if (!entry && if_not_found != OnEntryNotFound::RETURN_NULL) {
@@ -73,7 +73,7 @@ string UnityCatalog::GetDBPath() {
 	return internal_name;
 }
 
-string UnityCatalog::GetDefaultSchema() const {
+Identifier UnityCatalog::GetDefaultSchema() const {
 	return default_schema;
 }
 

--- a/src/uc_multi_file_list.cpp
+++ b/src/uc_multi_file_list.cpp
@@ -123,7 +123,7 @@ static void ScanParquetFile(ClientContext &context, const string &path,
 	vector<Identifier> input_table_names;
 	TableFunctionRef dummy_ref;
 	vector<LogicalType> return_types;
-	vector<string> return_names;
+	vector<Identifier> return_names;
 	TableFunctionBindInput bind_input(inputs, named_params, input_table_types, input_table_names, nullptr, nullptr,
 	                                  parquet_fn, dummy_ref);
 	auto bind_data = parquet_fn.bind(context, bind_input, return_types, return_names);

--- a/src/unity_catalog_extension.cpp
+++ b/src/unity_catalog_extension.cpp
@@ -83,7 +83,7 @@ static unique_ptr<Catalog> UnityCatalogAttach(optional_ptr<StorageExtensionInfo>
 
 	// check if we have a secret provided
 	string secret_name;
-	string default_schema;
+	Identifier default_schema;
 	for (auto &entry : info.options) {
 		auto lower_name = StringUtil::Lower(entry.first);
 		if (lower_name == "type" || lower_name == "read_only") {
@@ -91,7 +91,7 @@ static unique_ptr<Catalog> UnityCatalogAttach(optional_ptr<StorageExtensionInfo>
 		} else if (lower_name == "secret") {
 			secret_name = entry.second.ToString();
 		} else if (lower_name == "default_schema") {
-			default_schema = entry.second.ToString();
+			default_schema = Identifier(entry.second.ToString());
 		} else if (lower_name == "use_irc_scan_plan") {
 			credentials.use_irc_scan_plan = entry.second.DefaultCastAs(LogicalType::BOOLEAN).GetValue<bool>();
 		} else if (lower_name == "api_irc_endpoint_override") {
@@ -145,7 +145,7 @@ static unique_ptr<Catalog> UnityCatalogAttach(optional_ptr<StorageExtensionInfo>
 		//! No explicit default schema provided, ask the catalog:
 		// Fixme: default namespace endpoint not available in OSS unity catalog, hence we throw
 		try {
-			default_schema = UCAPI::GetDefaultSchema(context, credentials);
+			default_schema = Identifier(UCAPI::GetDefaultSchema(context, credentials));
 		} catch (Exception &e) {
 			UC_LOG_ERROR(context, "api.GetDefaultSchema failed: %s", e.what());
 		}

--- a/test/oss_local/catalog_managed_path_read.py
+++ b/test/oss_local/catalog_managed_path_read.py
@@ -1,60 +1,61 @@
-"""Driver for catalog_managed_path_read.test -- report C2, with the assertion corrected.
+"""Driver for catalog_managed_path_read.test: reading a catalog-managed table off storage.
 
-The report asks for a regression on a path-vs-catalog COUNT MISMATCH. That scenario is not
-reachable: since kernel v0.21.0 a path read of a catalog-managed table hard-errors rather than
-returning stale rows, so there is no mismatch to observe. Asserting one would encode the
-diagnosis we are correcting. What this test pins instead is the property that actually protects
-the user -- the path read FAILS, and the catalog read is the only way in.
+Such a read cannot return a stale-but-plausible count -- since kernel v0.21.0 it hard-errors
+instead of answering from the log on disk. So the property worth pinning is that the path read
+FAILS and the catalog is the only way in, not that two counts differ.
 
 Provisioning is hand-rolled because the storage location has to reach the body: `uctl create cmt`
-makes a MANAGED (= catalog-managed, in this UC build) table, then `uctl get` reports where UC put
-it, and that path is injected for the delta_scan attempt.
+makes a MANAGED (= catalog-managed, in this UC build) table, then UC reports where it put it, and
+that path is injected for the delta_scan attempt.
+
+TODO: once the provisioner can surface a table's storage location, express this as `@requires`.
+That supplies the per-run token and teardown, and the uuid below goes away with it.
 """
 
 import json
 import os
+import uuid
 
 import pytest
 
 from ducktest import run_paired
 from uc import uctl
 
-TABLE = "catalog_managed_c2"
+CATALOG = "duck"
 SCHEMA = "cmt"  # MANAGED -> catalog-managed commits; see scripts/oss_uc_image/uctl
 
 
-def _storage_location(schema, table):
-    """Where UC placed the managed table, from `uctl get`."""
-    r = uctl("get", schema, table)
-    out = (r.stdout or "").strip()
-    try:
-        return json.loads(out).get("storage_location")
-    except json.JSONDecodeError:
-        # Tolerate a non-JSON CLI rendering: find the first path-looking token.
-        for line in out.splitlines():
-            if "storage_location" in line:
-                return line.split(None, 1)[-1].strip().strip('",')
-    return None
+def _storage_location(catalog, schema, table):
+    """Where UC placed the managed table.
+
+    Goes through uctl's raw escape hatch to pass `--output json`: the CLI otherwise renders an
+    ASCII table, which is for humans and would have to be scraped.
+    """
+    r = uctl("uc", "table", "get", "--full_name", f"{catalog}.{schema}.{table}", "--output", "json")
+    return json.loads((r.stdout or "").strip()).get("storage_location")
 
 
 @pytest.mark.oss_local
 def test_catalog_managed_path_read(request, uc_server):
-    uctl("drop", SCHEMA, TABLE, check=False)
-    uctl("create", SCHEMA, TABLE, "id INT, name STRING")
+    # Unique per run: a container shared across sessions (--existing-service) would otherwise
+    # collide on the table name.
+    table = f"catalog_managed_c2_{uuid.uuid4().hex[:8]}"
+    uctl("create", SCHEMA, table, "id INT, name STRING")
 
-    location = _storage_location(SCHEMA, TABLE)
-    if not location:
-        uctl("drop", SCHEMA, TABLE, check=False)
-        pytest.skip("could not determine the managed table's storage_location from `uctl get`")
-
-    env = {
-        **os.environ,
-        "UC_TEST_CATALOG": "duck",
-        "UC_TEST_SCHEMA": SCHEMA,
-        "UC_TEST_TABLE": TABLE,
-        "UC_CMT_STORAGE_LOCATION": location,
-    }
     try:
+        location = _storage_location(CATALOG, SCHEMA, table)
+        if not location:
+            # Not a skip: a MANAGED table always has one, so its absence is a real defect and
+            # skipping would bury the only thing this test needs.
+            raise AssertionError(f"UC reported no storage_location for {CATALOG}.{SCHEMA}.{table}")
+
+        env = {
+            **os.environ,
+            "UC_TEST_CATALOG": CATALOG,
+            "UC_TEST_SCHEMA": SCHEMA,
+            "UC_TEST_TABLE": table,
+            "UC_CMT_STORAGE_LOCATION": location,
+        }
         run_paired(request, env=env)
     finally:
-        uctl("drop", SCHEMA, TABLE, check=False)
+        uctl("drop", SCHEMA, table, check=False)

--- a/test/oss_local/catalog_managed_path_read.py
+++ b/test/oss_local/catalog_managed_path_read.py
@@ -1,0 +1,60 @@
+"""Driver for catalog_managed_path_read.test -- report C2, with the assertion corrected.
+
+The report asks for a regression on a path-vs-catalog COUNT MISMATCH. That scenario is not
+reachable: since kernel v0.21.0 a path read of a catalog-managed table hard-errors rather than
+returning stale rows, so there is no mismatch to observe. Asserting one would encode the
+diagnosis we are correcting. What this test pins instead is the property that actually protects
+the user -- the path read FAILS, and the catalog read is the only way in.
+
+Provisioning is hand-rolled because the storage location has to reach the body: `uctl create cmt`
+makes a MANAGED (= catalog-managed, in this UC build) table, then `uctl get` reports where UC put
+it, and that path is injected for the delta_scan attempt.
+"""
+
+import json
+import os
+
+import pytest
+
+from ducktest import run_paired
+from uc import uctl
+
+TABLE = "catalog_managed_c2"
+SCHEMA = "cmt"  # MANAGED -> catalog-managed commits; see scripts/oss_uc_image/uctl
+
+
+def _storage_location(schema, table):
+    """Where UC placed the managed table, from `uctl get`."""
+    r = uctl("get", schema, table)
+    out = (r.stdout or "").strip()
+    try:
+        return json.loads(out).get("storage_location")
+    except json.JSONDecodeError:
+        # Tolerate a non-JSON CLI rendering: find the first path-looking token.
+        for line in out.splitlines():
+            if "storage_location" in line:
+                return line.split(None, 1)[-1].strip().strip('",')
+    return None
+
+
+@pytest.mark.oss_local
+def test_catalog_managed_path_read(request, uc_server):
+    uctl("drop", SCHEMA, TABLE, check=False)
+    uctl("create", SCHEMA, TABLE, "id INT, name STRING")
+
+    location = _storage_location(SCHEMA, TABLE)
+    if not location:
+        uctl("drop", SCHEMA, TABLE, check=False)
+        pytest.skip("could not determine the managed table's storage_location from `uctl get`")
+
+    env = {
+        **os.environ,
+        "UC_TEST_CATALOG": "duck",
+        "UC_TEST_SCHEMA": SCHEMA,
+        "UC_TEST_TABLE": TABLE,
+        "UC_CMT_STORAGE_LOCATION": location,
+    }
+    try:
+        run_paired(request, env=env)
+    finally:
+        uctl("drop", SCHEMA, TABLE, check=False)

--- a/test/oss_local/catalog_managed_path_read.test
+++ b/test/oss_local/catalog_managed_path_read.test
@@ -1,5 +1,5 @@
 # name: test/oss_local/catalog_managed_path_read.test
-# description: a path-based read of a catalog-managed table must fail rather than answer from storage (report C2). The report asks for a path-vs-catalog count mismatch; that is unreachable, because the kernel refuses the path read outright -- so this pins the refusal and the catalog read that replaces it.
+# description: a path-based read of a catalog-managed table must fail rather than answer from storage. The kernel refuses to open one without the catalog's version, so a stale-but-plausible count is unreachable; this pins the refusal and the catalog read that replaces it.
 # group: [oss_local]
 
 require parquet
@@ -33,7 +33,7 @@ statement ok
 USE duck.{UC_TEST_SCHEMA};
 
 # -----------------------------------------------------------------------------
-# The catalog path is the correct answer -- step 1 of the reporter's repro
+# The catalog path is the correct answer
 #
 
 statement ok
@@ -45,11 +45,11 @@ SELECT count(*) FROM {UC_TEST_TABLE};
 2
 
 # -----------------------------------------------------------------------------
-# The path read refuses -- their step 3, with the outcome corrected
+# The path read refuses
 #
-# The report expects a stale count here. It cannot happen: the kernel will not open a
-# catalog-managed table without the catalog's version, so the read errors instead. That is
-# the property worth pinning -- a wrong answer is impossible because there is no answer.
+# A stale count is impossible here: the kernel will not open a catalog-managed table without
+# the catalog's version, so the read errors instead. A wrong answer cannot occur because
+# there is no answer.
 #
 
 statement error
@@ -85,6 +85,10 @@ SELECT id, name FROM {UC_TEST_TABLE} ORDER BY id;
 ----
 1	first
 2	second
+
+# `USE` above made duck the default database, which cannot be detached while selected
+statement ok
+USE memory;
 
 statement ok
 DETACH duck;

--- a/test/oss_local/catalog_managed_path_read.test
+++ b/test/oss_local/catalog_managed_path_read.test
@@ -1,0 +1,90 @@
+# name: test/oss_local/catalog_managed_path_read.test
+# description: a path-based read of a catalog-managed table must fail rather than answer from storage (report C2). The report asks for a path-vs-catalog count mismatch; that is unreachable, because the kernel refuses the path read outright -- so this pins the refusal and the catalog read that replaces it.
+# group: [oss_local]
+
+require parquet
+
+require unity_catalog
+
+require delta
+
+require httpfs
+
+require-env UC_TEST_CATALOG
+
+require-env UC_TEST_SCHEMA
+
+require-env UC_TEST_TABLE
+
+require-env UC_CMT_STORAGE_LOCATION
+
+statement ok
+CREATE SECRET (
+    TYPE UNITY_CATALOG,
+    TOKEN 'not-used',
+    ENDPOINT 'http://127.0.0.1:8080',
+    AWS_REGION 'us-east-2'
+);
+
+statement ok
+ATTACH '{UC_TEST_CATALOG}' AS duck (TYPE UNITY_CATALOG, DEFAULT_SCHEMA '{UC_TEST_SCHEMA}');
+
+statement ok
+USE duck.{UC_TEST_SCHEMA};
+
+# -----------------------------------------------------------------------------
+# The catalog path is the correct answer -- step 1 of the reporter's repro
+#
+
+statement ok
+INSERT INTO {UC_TEST_TABLE} VALUES (1, 'first'), (2, 'second');
+
+query I
+SELECT count(*) FROM {UC_TEST_TABLE};
+----
+2
+
+# -----------------------------------------------------------------------------
+# The path read refuses -- their step 3, with the outcome corrected
+#
+# The report expects a stale count here. It cannot happen: the kernel will not open a
+# catalog-managed table without the catalog's version, so the read errors instead. That is
+# the property worth pinning -- a wrong answer is impossible because there is no answer.
+#
+
+statement error
+SELECT count(*) FROM delta_scan('{UC_CMT_STORAGE_LOCATION}');
+----
+is a catalog-managed Delta table
+
+# The message must point at the fix, not just at the refusal
+statement error
+SELECT count(*) FROM delta_scan('{UC_CMT_STORAGE_LOCATION}');
+----
+TYPE unity_catalog
+
+# The other way to reach storage: a plain delta ATTACH. This succeeds -- the refusal fires
+# when the snapshot is opened, on first query, not at attach time.
+statement ok
+ATTACH '{UC_CMT_STORAGE_LOCATION}' AS bypass (TYPE delta);
+
+statement error
+SELECT count(*) FROM bypass;
+----
+is a catalog-managed Delta table
+
+statement ok
+DETACH bypass;
+
+# -----------------------------------------------------------------------------
+# The catalog remains the way in, and still answers
+#
+
+query II
+SELECT id, name FROM {UC_TEST_TABLE} ORDER BY id;
+----
+1	first
+2	second
+
+statement ok
+DETACH duck;

--- a/test/oss_local/char_varchar_width.py
+++ b/test/oss_local/char_varchar_width.py
@@ -1,0 +1,67 @@
+"""Driver for char_varchar_width.test -- the reporter's C1 acceptance step, run through UC.
+
+Their repro writes the over-length value through `ATTACH … (TYPE unity_catalog)`, which reaches
+`DeltaCatalog::PlanInsert` via `child_catalog_mode` -- a different branch from the plain
+`ATTACH … (TYPE delta)` that duckdb-delta's own tests cover. So this exists to prove the width
+check is REACHABLE through the catalog plumbing, not to re-test the rule.
+
+The fixture is a committed Delta log rather than a TableSpec, and has to be: the bound lives in
+Delta field metadata (`__CHAR_VARCHAR_TYPE_STRING`) that only Spark writes. DuckDB has no
+fixed-length char type at all -- it parses CHAR(5) and discards the width -- so neither the duckdb
+middleman nor `uctl create` can express it. We copy `data/char_varchar_c1` into the table's
+storage location (a copy, so the INSERTs below never mutate the committed tree) and register that
+location with UC.
+"""
+
+import os
+import pathlib
+import shutil
+import subprocess
+
+import pytest
+
+from ducktest import run_paired
+from uc import uctl
+
+TABLE = "char_varchar_c1"
+SCHEMA = "plain"  # EXTERNAL -> uctl gives the table a location we can stage into
+FIXTURE = pathlib.Path(__file__).resolve().parents[2] / "data" / "char_varchar_c1"
+
+
+def _data_root(container):
+    """The data dir the server is using -- bind-mounted at the identical path on host and
+    container (scripts/oss_uc_image/run), so a host-side copy lands where UC will look."""
+    r = subprocess.run(
+        ["docker", "exec", container, "printenv", "DUCKTEST_UC_DATA_DIR"],
+        capture_output=True,
+        text=True,
+    )
+    return (r.stdout.strip() if r.returncode == 0 else "") or "/home/unitycatalog/etc/data"
+
+
+@pytest.mark.oss_local
+def test_char_varchar_width(request, uc_server):
+    container = os.environ.get("DUCKTEST_UC_CONTAINER", "ducktest-uc")
+    location = pathlib.Path(_data_root(container)) / "duck" / SCHEMA / TABLE
+
+    # Stage a fresh copy: uctl create derives this same storage_location, so the registration
+    # lands on the log we just placed.
+    shutil.rmtree(location, ignore_errors=True)
+    shutil.copytree(FIXTURE, location)
+
+    # UC's own column types are irrelevant to the check -- enforcement reads the Delta schema,
+    # and UC drops the width anyway -- but keep them honest.
+    uctl("drop", SCHEMA, TABLE, check=False)
+    uctl("create", SCHEMA, TABLE, "id INT, code STRING")
+
+    env = {
+        **os.environ,
+        "UC_TEST_CATALOG": "duck",
+        "UC_TEST_SCHEMA": SCHEMA,
+        "UC_TEST_TABLE": TABLE,
+    }
+    try:
+        run_paired(request, env=env)
+    finally:
+        uctl("drop", SCHEMA, TABLE, check=False)
+        shutil.rmtree(location, ignore_errors=True)

--- a/test/oss_local/char_varchar_width.py
+++ b/test/oss_local/char_varchar_width.py
@@ -1,9 +1,9 @@
-"""Driver for char_varchar_width.test -- the reporter's C1 acceptance step, run through UC.
+"""Driver for char_varchar_width.test: an over-length write through the UC catalog path.
 
-Their repro writes the over-length value through `ATTACH … (TYPE unity_catalog)`, which reaches
-`DeltaCatalog::PlanInsert` via `child_catalog_mode` -- a different branch from the plain
-`ATTACH … (TYPE delta)` that duckdb-delta's own tests cover. So this exists to prove the width
-check is REACHABLE through the catalog plumbing, not to re-test the rule.
+A write through `ATTACH … (TYPE unity_catalog)` reaches `DeltaCatalog::PlanInsert` via
+`child_catalog_mode` -- a different branch from the plain `ATTACH … (TYPE delta)` that
+duckdb-delta's own tests cover. So this exists to prove the width check is REACHABLE through the
+catalog plumbing, not to re-test the rule itself.
 
 The fixture is a committed Delta log rather than a TableSpec, and has to be: the bound lives in
 Delta field metadata (`__CHAR_VARCHAR_TYPE_STRING`) that only Spark writes. DuckDB has no
@@ -11,57 +11,49 @@ fixed-length char type at all -- it parses CHAR(5) and discards the width -- so 
 middleman nor `uctl create` can express it. We copy `data/char_varchar_c1` into the table's
 storage location (a copy, so the INSERTs below never mutate the committed tree) and register that
 location with UC.
+
+TODO: once Spark-backed fixtures land, express this as `@requires` and let the provisioner do it.
+That supplies the per-run token and teardown, and most of this driver goes away.
 """
 
 import os
 import pathlib
 import shutil
-import subprocess
+import uuid
 
 import pytest
 
 from ducktest import run_paired
 from uc import uctl
 
-TABLE = "char_varchar_c1"
+CATALOG = "duck"
 SCHEMA = "plain"  # EXTERNAL -> uctl gives the table a location we can stage into
 FIXTURE = pathlib.Path(__file__).resolve().parents[2] / "data" / "char_varchar_c1"
 
 
-def _data_root(container):
-    """The data dir the server is using -- bind-mounted at the identical path on host and
-    container (scripts/oss_uc_image/run), so a host-side copy lands where UC will look."""
-    r = subprocess.run(
-        ["docker", "exec", container, "printenv", "DUCKTEST_UC_DATA_DIR"],
-        capture_output=True,
-        text=True,
-    )
-    return (r.stdout.strip() if r.returncode == 0 else "") or "/home/unitycatalog/etc/data"
-
-
 @pytest.mark.oss_local
 def test_char_varchar_width(request, uc_server):
-    container = os.environ.get("DUCKTEST_UC_CONTAINER", "ducktest-uc")
-    location = pathlib.Path(_data_root(container)) / "duck" / SCHEMA / TABLE
+    # Unique per run: a container shared across sessions (--existing-service) would otherwise
+    # collide on the table name and its storage location.
+    table = f"char_varchar_c1_{uuid.uuid4().hex[:8]}"
 
-    # Stage a fresh copy: uctl create derives this same storage_location, so the registration
-    # lands on the log we just placed.
-    shutil.rmtree(location, ignore_errors=True)
+    # uctl gives a plain table `<data dir>/<catalog>/<schema>/<table>`; stage the log there so the
+    # registration lands on it. The data dir is bind-mounted at the same path host and container.
+    location = pathlib.Path(uc_server.data_dir) / CATALOG / SCHEMA / table
     shutil.copytree(FIXTURE, location)
 
     # UC's own column types are irrelevant to the check -- enforcement reads the Delta schema,
     # and UC drops the width anyway -- but keep them honest.
-    uctl("drop", SCHEMA, TABLE, check=False)
-    uctl("create", SCHEMA, TABLE, "id INT, code STRING")
+    uctl("create", SCHEMA, table, "id INT, code STRING")
 
     env = {
         **os.environ,
-        "UC_TEST_CATALOG": "duck",
+        "UC_TEST_CATALOG": CATALOG,
         "UC_TEST_SCHEMA": SCHEMA,
-        "UC_TEST_TABLE": TABLE,
+        "UC_TEST_TABLE": table,
     }
     try:
         run_paired(request, env=env)
     finally:
-        uctl("drop", SCHEMA, TABLE, check=False)
+        uctl("drop", SCHEMA, table, check=False)
         shutil.rmtree(location, ignore_errors=True)

--- a/test/oss_local/char_varchar_width.test
+++ b/test/oss_local/char_varchar_width.test
@@ -1,5 +1,5 @@
 # name: test/oss_local/char_varchar_width.test
-# description: CHAR(n)/VARCHAR(n) width is enforced on writes that go through the UC catalog path (report C1). The bound lives in Delta field metadata that only Spark writes, so char_varchar_width.py hand-seeds the _delta_log; this body is the reporter's acceptance step -- an over-length INSERT through ATTACH ... (TYPE unity_catalog) must raise a clean error.
+# description: CHAR(n)/VARCHAR(n) width is enforced on writes that go through the UC catalog path -- an over-length INSERT through ATTACH ... (TYPE unity_catalog) must raise a clean error. The bound lives in Delta field metadata that only Spark writes, so char_varchar_width.py hand-seeds the _delta_log.
 # group: [oss_local]
 
 require parquet
@@ -55,10 +55,10 @@ SELECT id, code FROM {UC_TEST_TABLE} ORDER BY id;
 1	ABCDE
 
 # -----------------------------------------------------------------------------
-# Over the limit: rejected -- this is step 2 of the reporter's repro
+# Over the limit: rejected
 #
-# Their criterion is "step 2 raises a clean error". Reject, not truncate: the reference
-# writer rejects, and truncation would silently alter the value.
+# Reject rather than truncate: Spark refuses an over-length write, and truncating would
+# silently alter the value.
 #
 
 statement error
@@ -80,6 +80,10 @@ query I
 SELECT count(*) FROM {UC_TEST_TABLE};
 ----
 2
+
+# `USE` above made duck the default database, which cannot be detached while selected
+statement ok
+USE memory;
 
 statement ok
 DETACH duck;

--- a/test/oss_local/char_varchar_width.test
+++ b/test/oss_local/char_varchar_width.test
@@ -1,0 +1,85 @@
+# name: test/oss_local/char_varchar_width.test
+# description: CHAR(n)/VARCHAR(n) width is enforced on writes that go through the UC catalog path (report C1). The bound lives in Delta field metadata that only Spark writes, so char_varchar_width.py hand-seeds the _delta_log; this body is the reporter's acceptance step -- an over-length INSERT through ATTACH ... (TYPE unity_catalog) must raise a clean error.
+# group: [oss_local]
+
+require parquet
+
+require unity_catalog
+
+require delta
+
+require httpfs
+
+require-env UC_TEST_CATALOG
+
+require-env UC_TEST_SCHEMA
+
+require-env UC_TEST_TABLE
+
+statement ok
+CREATE SECRET (
+    TYPE UNITY_CATALOG,
+    TOKEN 'not-used',
+    ENDPOINT 'http://127.0.0.1:8080',
+    AWS_REGION 'us-east-2'
+);
+
+statement ok
+ATTACH '{UC_TEST_CATALOG}' AS duck (TYPE UNITY_CATALOG, DEFAULT_SCHEMA '{UC_TEST_SCHEMA}');
+
+statement ok
+USE duck.{UC_TEST_SCHEMA};
+
+# -----------------------------------------------------------------------------
+# The bound is visible through the catalog as a plain string
+#
+# UC drops the width in its own type map, so the catalog view will never show char(5).
+# That is expected and is not what enforcement depends on.
+#
+
+query I
+SELECT count(*) FROM duckdb_tables() WHERE database_name = 'duck' AND table_name = '{UC_TEST_TABLE}';
+----
+1
+
+# -----------------------------------------------------------------------------
+# At the limit: accepted
+#
+
+statement ok
+INSERT INTO {UC_TEST_TABLE} VALUES (1, 'ABCDE');
+
+query II
+SELECT id, code FROM {UC_TEST_TABLE} ORDER BY id;
+----
+1	ABCDE
+
+# -----------------------------------------------------------------------------
+# Over the limit: rejected -- this is step 2 of the reporter's repro
+#
+# Their criterion is "step 2 raises a clean error". Reject, not truncate: the reference
+# writer rejects, and truncation would silently alter the value.
+#
+
+statement error
+INSERT INTO {UC_TEST_TABLE} VALUES (2, 'ABCDEFGH');
+----
+is declared as char(5)
+
+# Nothing from the rejected statement committed
+query I
+SELECT count(*) FROM {UC_TEST_TABLE};
+----
+1
+
+# NULLs are unbounded
+statement ok
+INSERT INTO {UC_TEST_TABLE} VALUES (3, NULL);
+
+query I
+SELECT count(*) FROM {UC_TEST_TABLE};
+----
+2
+
+statement ok
+DETACH duck;

--- a/test/py/uc/oss.py
+++ b/test/py/uc/oss.py
@@ -95,7 +95,7 @@ class OssProvisioner:
         wd = getattr(self._config, "sqllogic_working_dir", None) or os.getcwd()
         return find_duckdb(self._config, wd)
 
-    def provision(self, specs, token, *, dry_run=False, params=None) -> OssBindings:
+    def provision(self, specs, token, *, dry_run=False, params=None, config=None) -> OssBindings:
         os.environ.setdefault("UC_TEST_CATALOG", server._CATALOG)  # "duck"
         catalog = os.environ["UC_TEST_CATALOG"]
         # A parametrized test's `schema` param picks the REPL context; else first rw

--- a/test/py/uc/oss.py
+++ b/test/py/uc/oss.py
@@ -38,7 +38,7 @@ _FIXTURES = REPO_ROOT / "test" / "fixtures"
 # DuckDB logical types -> UC/Spark types for `uctl create` column specs.
 UC_TYPE_MAP = {
     "INTEGER": "INT",
-    "BIGINT": "BIGINT",
+    "BIGINT": "LONG",
     "SMALLINT": "SMALLINT",
     "TINYINT": "TINYINT",
     "VARCHAR": "STRING",

--- a/uv.lock
+++ b/uv.lock
@@ -231,8 +231,8 @@ wheels = [
 
 [[package]]
 name = "duckdb-pytest-driver"
-version = "0.1.0"
-source = { git = "https://github.com/benfleis/duckdb-pytest-driver?branch=dev%2Fv0.2#fd97963d048cfa68f1fbffb3978d05cce60b0e9b" }
+version = "0.2.0"
+source = { git = "https://github.com/benfleis/duckdb-pytest-driver?branch=dev%2Fv0.3#dd710fcf64a73c693279a44a93923e7bc27280db" }
 dependencies = [
     { name = "pytest" },
 ]
@@ -259,7 +259,7 @@ dev = [
 [package.metadata.requires-dev]
 dev = [
     { name = "databricks-sdk" },
-    { name = "duckdb-pytest-driver", extras = ["xdist"], git = "https://github.com/benfleis/duckdb-pytest-driver?branch=dev%2Fv0.2" },
+    { name = "duckdb-pytest-driver", extras = ["xdist"], git = "https://github.com/benfleis/duckdb-pytest-driver?branch=dev%2Fv0.3" },
     { name = "pre-commit", specifier = ">=0.6.1" },
 ]
 


### PR DESCRIPTION
Test the catalog write path, bump duckdb main

Two tests exercise what only the catalog path reaches: an over-length CHAR/VARCHAR
write must be refused, and a path read of a catalog-managed table must fail rather
than answer from storage. Both go through ATTACH ... (TYPE unity_catalog), which
plans inserts down a different branch than a plain delta attach.

Also:
- update delta with underlying fixes
- update duckdb to main, pull in Identifier patches and default schema tweaks,
  and delta ref
- testing update: UC has no BIGINT; its 64-bit type is LONG, update mapping
